### PR TITLE
Add support for NCEI historical RAP analyses

### DIFF
--- a/herbie/archive.py
+++ b/herbie/archive.py
@@ -54,7 +54,7 @@ import pandas as pd
 import pygrib
 import requests
 from pyproj import CRS
-
+from os.path import exists
 import herbie.models as models_template
 
 # NOTE: These config dict values are retrieved from __init__ and read
@@ -245,6 +245,8 @@ class Herbie:
         if list(self.SOURCES)[0] == "local":
             # TODO: Experimental special case, not very elegant yet.
             self.idx = Path(str(self.grib) + self.IDX_SUFFIX)
+            if not self.idx.exists():
+                self.idx = Path(str(self.grib).replace(".grb2", self.IDX_SUFFIX))
             return None
 
         # If priority list is set, we want to search SOURCES in that
@@ -275,9 +277,12 @@ class Herbie:
                 found_grib = True
                 self.grib = url
                 self.grib_source = source
-            if self.idx is None and self._check_idx(url):
+            idx_exists, idx_url = self._check_idx(url)
+            print(url)
+            print(idx_url)
+            if idx_exists:
                 found_idx = True
-                self.idx = url + self.IDX_SUFFIX
+                self.idx = idx_url
                 self.idx_source = source
 
             if verbose:
@@ -381,7 +386,13 @@ class Herbie:
         """Check if an index file exist for the GRIB2 URL."""
         if not url.endswith(self.IDX_SUFFIX):
             url += self.IDX_SUFFIX
-        return requests.head(url).ok
+        url_exists = requests.head(url).ok
+        # Check for index files where .inv replaces grb2 rather than being appended 
+        url_rep = url
+        if not url_exists:
+            url_rep = url.replace(".grb2" + self.IDX_SUFFIX, self.IDX_SUFFIX)
+            url_exists = requests.head(url_rep).ok
+        return url_exists, url_rep
 
     @property
     def get_remoteFileName(self, source=None):

--- a/herbie/archive.py
+++ b/herbie/archive.py
@@ -54,7 +54,7 @@ import pandas as pd
 import pygrib
 import requests
 from pyproj import CRS
-from os.path import exists
+
 import herbie.models as models_template
 
 # NOTE: These config dict values are retrieved from __init__ and read

--- a/herbie/models/rap.py
+++ b/herbie/models/rap.py
@@ -44,6 +44,7 @@ class rap_ncei:
             "nomads product description": "https://www.ncei.noaa.gov/products/weather-climate-models/rapid-refresh-update",
         }
         self.PRODUCTS = {
+            "historical/analysis": "RAP 13 km",
             "rap-130-13km/analysis": "RAP 13 km",  # longer archive
             "rap-130-13km/forecast": "RAP 13 km",  # very short archive
             "rap-252-20km/analysis": "RAP 20 km",


### PR DESCRIPTION
I added support for downloading RAP grib2 analysis files from the [historical NCEI online directory](https://www.ncei.noaa.gov/data/rapid-refresh/access/historical/analysis/) since the old RAP and RUC files dating to 2005 were moved there recently. I had to make some modifications to how the .inv files are found because they replaced the `.grb2` extension with `.inv` rather than appending it. The new code should try the original format before trying the replacement option. I did a local test and the download and xarray functionality appeared to work.