### PR TITLE
Add AWS as source for ECMWF forecasts

### DIFF
--- a/herbie/models/ecmwf.py
+++ b/herbie/models/ecmwf.py
@@ -11,6 +11,8 @@ See the `media release <https://www.ecmwf.int/en/about/media-centre/news/2022/ec
 - Licence Statement: This data is published under a Creative Commons Attribution 4.0 International (CC BY 4.0). https://creativecommons.org/licenses/by/4.0/
 - Disclaimer: ECMWF does not accept any liability whatsoever for any error or omission in the data, their availability, or for any loss or damage arising from their use.
 
+https://confluence.ecmwf.int/display/DAC/ECMWF+open+data%3A+real-time+forecasts
+
 """
 
 
@@ -23,7 +25,7 @@ class ecmwf:
 
         self.DESCRIPTION = "ECMWF open data"
         self.DETAILS = {
-            "ECMWF": "https://confluence.ecmwf.int/display/UDOC/ECMWF+Open+Data+-+Real+Time",
+            "ECMWF": "https://confluence.ecmwf.int/display/DAC/ECMWF+open+data%3A+real-time+forecasts",
         }
         self.PRODUCTS = {
             "oper": "operational high-resolution forecast, atmospheric fields",

--- a/herbie/models/ecmwf.py
+++ b/herbie/models/ecmwf.py
@@ -2,13 +2,13 @@
 ## January 26, 2022
 
 """
-A Herbie template for the ECMWF opendata GRIB2 files.
+A Herbie template for the ECMWF Open Data GRIB2 files.
 
 See the `media release <https://www.ecmwf.int/en/about/media-centre/news/2022/ecmwf-makes-wide-range-data-openly-available>`_.
 
 - Copyright statement: Copyright "© 2022 European Centre for Medium-Range Weather Forecasts (ECMWF)".
 - Source www.ecmwf.int
-- Licence Statement: This data is published under a Creative Commons Attribution 4.0 International (CC BY 4.0). https://creativecommons.org/licenses/by/4.0/
+- License Statement: This data is published under a Creative Commons Attribution 4.0 International (CC BY 4.0). https://creativecommons.org/licenses/by/4.0/
 - Disclaimer: ECMWF does not accept any liability whatsoever for any error or omission in the data, their availability, or for any loss or damage arising from their use.
 
 https://confluence.ecmwf.int/display/DAC/ECMWF+open+data%3A+real-time+forecasts
@@ -50,7 +50,7 @@ class ecmwf:
 
         self.SOURCES = {
             "azure": f"https://ai4edataeuwest.blob.core.windows.net/ecmwf/{post_root}",
-            "aws": f"https://ecmwf-forecasts.s3.eu-central-1.amazonaws.com/{post_root}"
+            "aws": f"https://ecmwf-forecasts.s3.eu-central-1.amazonaws.com/{post_root}",
             "ecmwf": f"https://data.ecmwf.int/forecasts/{post_root}",
         }
         self.IDX_SUFFIX = [".index"]

--- a/herbie/models/ecmwf.py
+++ b/herbie/models/ecmwf.py
@@ -50,6 +50,7 @@ class ecmwf:
 
         self.SOURCES = {
             "azure": f"https://ai4edataeuwest.blob.core.windows.net/ecmwf/{post_root}",
+            "aws": f"https://ecmwf-forecasts.s3.eu-central-1.amazonaws.com/{post_root}"
             "ecmwf": f"https://data.ecmwf.int/forecasts/{post_root}",
         }
         self.IDX_SUFFIX = [".index"]


### PR DESCRIPTION
Closes #148 

ROOT for ECMWF forecasts data hosted on AWS was published here:
https://confluence.ecmwf.int/display/DAC/ECMWF+open+data%3A+real-time+forecasts