### PR TITLE
only print xarray note if self.verbose=True

### DIFF
--- a/herbie/core.py
+++ b/herbie/core.py
@@ -1143,9 +1143,10 @@ class Herbie:
                 data_vars.remove("gribfile_projection")
                 Hxr = xr.concat(Hxr, dim="step", data_vars=data_vars)
             except:
-                print(
-                    f"Note: Returning a list of [{len(Hxr)}] xarray.Datasets because cfgrib opened with multiple hypercubes."
-                )
+                if self.verbose:
+                    print(
+                        f"Note: Returning a list of [{len(Hxr)}] xarray.Datasets because cfgrib opened with multiple hypercubes."
+                    )
             return Hxr
 
     # Shortcut Methods below


### PR DESCRIPTION
In the `xarray` function in `core.py`, if there is more than one hypercube returned by the query, a note will always be printed: `f"Note: Returning a list of [{len(Hxr)}] xarray.Datasets because cfgrib opened with multiple hypercubes."`.

This commit changes this behavior to only print the note if `self.verbose` is `True`.