### PR TITLE
Fix the UnicodeDecodeError: 'utf-8' error that occurred when Windows usernames contained UTF-8 characters.

### DIFF
--- a/herbie/__init__.py
+++ b/herbie/__init__.py
@@ -134,7 +134,7 @@ if not _config_path.exists():
 
     # Create config.toml file
     _config_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(_config_path, "w") as f:
+    with open(_config_path, "w", encoding="utf-8") as f:
         toml_string = toml.dump(toml.loads(default_toml), f)
 
     # Create custom_template.py placeholder


### PR DESCRIPTION
When Windows usernames contain UTF-8 characters, such as Chinese characters, a UnicodeDecodeError: 'utf-8' error would occur. This PR fixed this issue.