### PR TITLE
Refine config file creation

### DIFF
--- a/herbie/__init__.py
+++ b/herbie/__init__.py
@@ -1,6 +1,3 @@
-## Brian Blaylock
-## April 28, 2021
-
 """
 ██  ██  ██  ██  ██  ██  ██  ██  ██  ██  ██  ██  ██  ██  ██  ██  ██  ██
   ██  ██  ██  ██  ██  ██  ██  ██  ██  ██  ██  ██  ██  ██  ██  ██  ██  ██
@@ -24,15 +21,18 @@
 
 import os
 from pathlib import Path
+
 import toml
+
+from herbie.misc import ANSI
 
 __author__ = "Brian K. Blaylock"
 __meet_Herbie__ = "https://en.wikipedia.org/wiki/Herbie"
 __movie_clips__ = "https://youtube.com/playlist?list=PLrSOkJxBTv53gvwbw9pVlMm-1C2PUHJx7"
 
 try:
-    ## TODO: Will the `_version.py` file *always* be present? What if the
-    ## TODO:   person doesn't do "install"
+    ## TODO: Will the `_version.py` file *always* be present?
+    ## TODO: What if the person doesn't do "pip install"
     from ._version import __version__, __version_tuple__
 except:
     __version__ = "unknown"
@@ -40,8 +40,8 @@ except:
 
 
 ########################################################################
-# Append Path object with my custom expand method so user can use
-# environment variables in the config file (e.g., ${HOME}).
+# Overload Path object with my custom `expand` method so the user can
+# set environment variables in the config file (e.g., ${HOME}).
 def _expand(self, resolve=False, absolute=False):
     """
     Fully expand the Path with the given environment variables.
@@ -68,38 +68,48 @@ def _expand(self, resolve=False, absolute=False):
 Path.expand = _expand
 
 ########################################################################
-# Herbie configuration file
-# Configuration file is save in `~/config/herbie/config.toml`
+# Herbie configuration files
+
+# Configuration file will be created in `~/config/herbie/config.toml`
 _config_path = Path("~/.config/herbie/config.toml").expand()
 
+# The location data data will be saved when it is downloaded.
 # NOTE: The `\\` is an escape character in TOML.
 # For Windows paths "C:\\user\\"" needs to be "C:\\\\user\\\\""
 _save_dir = str(Path("~/data").expand())
 _save_dir = _save_dir.replace("\\", "\\\\")
 
-
-########################################################################
 # Default TOML Configuration Values
-default_toml = f"""
+default_toml = f"""# Herbie defaults
+
 [default]
 model = "hrrr"
 fxx = 0
 save_dir = "{_save_dir}"
 overwrite = false
 verbose = true
+
+# =============================================================================
+# You can set the priority order for checking data sources.
+# If you don't specify a default priority, Herbie will check each source in the
+# order listed in the model template file. Beware: setting a default priority
+# might prevent you from checking all available sources.
+#
+#priority = ['aws', 'nomads', 'google', 'etc.']
+
 """
 
-########################################################################
-# Default custom_template.py placeholder
+# Default `custom_template.py` placeholder
 default_custom_template = """
 # ======================
 # Private Model Template
 # ======================
-# Find more details at
-# https://herbie.readthedocs.io/user_guide/extend.html
+# Read more details at
+# https://herbie.readthedocs.io/en/stable/user_guide/extend.html
 
-# Uncomment class, add additional classes, and edit SOURCES dictionary
-# to help Herbie locate your locally stored GRIB2 files.
+# Uncomment and edit the class below, add additional classes, and edit
+# the SOURCES dictionary to help Herbie locate your locally stored GRIB2
+# files.
 
 '''
 class model1_name:
@@ -109,11 +119,14 @@ class model1_name:
             "local_main": "These GRIB2 files are from a locally-stored modeling experiments."
             "local_alt": "These GRIB2 files are an alternative location for these model files."
         }
+
         # These PRODUCTS are optional but can provide an additional parameter to search for files.
         self.PRODUCTS = {
             "prs": "3D pressure level fields",
             "sfc": "Surface level fields",
         }
+
+        # These are the paths to your local GRIB2 files.
         self.SOURCES = {
             "local_main": f"/path/to/your/model1/templated/with/{self.model}/gribfiles/{self.date:%Y%m%d%H}/nest{self.nest}/the_file.t{self.date:%H}z.{self.product}.f{self.fxx:02d}.grib2",
             "local_alt": f"/alternative/path/to/your/model1/templated/with/{self.model}/gribfiles/{self.date:%Y%m%d%H}/nest{self.nest}/the_file.t{self.date:%H}z.{self.product}.f{self.fxx:02d}.grib2",
@@ -123,46 +136,50 @@ class model1_name:
 """
 
 ########################################################################
-# If a config file isn't found, make one
-if not _config_path.exists():
-    print(
-        f" ╭─────────────────────────────────────────────────╮\n"
-        f" │ I'm building Herbie's default config file.      │\n"
-        f" ╰╥────────────────────────────────────────────────╯\n"
-        f" 👷🏻‍♂️"
-    )
+# Load config file (create one if needed)
+try:
+    # Load the Herbie config file
+    config = toml.load(_config_path)
+except:
+    try:
+        # Create the Herbie config file
+        _config_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(_config_path, "w", encoding="utf-8") as f:
+            f.write(default_toml)
 
-    # Create config.toml file
-    _config_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(_config_path, "w", encoding="utf-8") as f:
-        toml_string = toml.dump(toml.loads(default_toml), f)
+        # Create `custom_template.py` placeholder
+        _init_path = _config_path.parent / "__init__.py"
+        _custom_path = _config_path.parent / "custom_template.py"
+        if not _init_path.exists():
+            with open(_init_path, "w") as f:
+                pass
+        if not _custom_path.exists():
+            with open(_custom_path, "w") as f:
+                f.write(default_custom_template)
 
-    # Create custom_template.py placeholder
-    _init_path = _config_path.parent / "__init__.py"
-    _custom_path = _config_path.parent / "custom_template.py"
-    if not _init_path.exists():
-        with open(_init_path, "w") as f:
-            pass
-    if not _custom_path.exists():
-        with open(_custom_path, "w") as f:
-            f.write(default_custom_template)
+        print(
+            f" ╭─{ANSI.herbie}─────────────────────────────────────────────╮\n"
+            f" │ INFO: Created a default config file.                 │\n"
+            f" │ You may view/edit Herbie's configuration here:       │\n"
+            f" │ {ANSI.orange}{str(_config_path):^50s}{ANSI.reset}   │\n"
+            f" ╰──────────────────────────────────────────────────────╯\n"
+        )
 
-    print(
-        f" ╭─────────────────────────────────────────────────╮\n"
-        f" │ You're ready to go.                             │\n"
-        f" │ You may edit the config file here:              │\n"
-        f" │ {str(_config_path):<45s}   │\n"
-        f" ╰╥────────────────────────────────────────────────╯\n"
-        f" 👷🏻‍♂️"
-    )
+        # Load the new Herbie config file
+        config = toml.load(_config_path)
+    except (FileNotFoundError, PermissionError, IOError):
+        print(
+            f" ╭─{ANSI.herbie}─────────────────────────────────────────────╮\n"
+            f" │ WARNING: Unable to create config file at             │\n"
+            f" │ {ANSI.orange}{str(_config_path):^50s}{ANSI.reset}   │\n"
+            f" │ Herbie will use standard default settings.           │\n"
+            f" ╰──────────────────────────────────────────────────────╯\n"
+        )
+        config = toml.loads(default_toml)
 
 
-########################################################################
-# Read the config file
-config = toml.load(_config_path)
-
+# Expand the full path for `save_dir`
 config["default"]["save_dir"] = Path(config["default"]["save_dir"]).expand()
-
 
 from herbie.core import Herbie
 from herbie.fast import FastHerbie, Herbie_latest

--- a/herbie/misc.py
+++ b/herbie/misc.py
@@ -18,8 +18,6 @@
   ██  ██  ██  ██  ██  ██  ██  ██  ██  ██  ██  ██  ██  ██  ██  ██  ██  ██
 """
 
-from herbie import Path
-
 
 class hc:
     """Herbie Color Pallette"""

--- a/herbie/models/__init__.py
+++ b/herbie/models/__init__.py
@@ -7,36 +7,43 @@ template by setting ``model='template_class_name'``. For example:
 Where "hrrr" is the name of the template class located in models/hrrr.py.
 """
 
-from pathlib import Path
 import sys
+from pathlib import Path
+
+from herbie.misc import ANSI
 
 # ======================================================================
 #                     Import Public Model Templates
 # ======================================================================
-from .hrrr import *
-from .gfs import *
-from .nam import *
-from .navgem import *
-from .nogaps import *
-from .nbm import *
-from .nexrad import *
-from .rap import *
-from .rrfs import *
 from .ecmwf import *
 from .gefs import *
+from .gfs import *
+from .hafs import *
+from .hrdps import *
+from .hrrr import *
+from .nam import *
+from .navgem import *
+from .nbm import *
+from .nexrad import *
+from .nogaps import *
+from .rap import *
+from .rrfs import *
 from .rtma import *
 from .urma import *
-from .hrdps import *
-from .hafs import *
 
 # ======================================================================
 #                     Import Private Model Templates
 # ======================================================================
 _custom_template_file = Path("~/.config/herbie/custom_template.py").expand()
 
-if _custom_template_file.exists():
-    try:
+try:
+    if _custom_template_file.exists():
         sys.path.insert(1, str(_custom_template_file.parent))
         from custom_template import *
-    except:
-        print(f"🤕 Herbie could not load custom template from {_custom_template_file}.")
+except:
+    print(
+        f" ╭─{ANSI.herbie}─────────────────────────────────────────────╮\n"
+        f" │ WARNING: Could not load custom template from         │\n"
+        f" │ {ANSI.orange}{str(_custom_template_file):^50s}{ANSI.reset}   │\n"
+        f" ╰──────────────────────────────────────────────────────╯\n"
+    )

--- a/test.toml
+++ b/test.toml
@@ -1,0 +1,17 @@
+
+# Herbie defaults
+
+[default]
+model = "hrrr"
+fxx = 0
+save_dir = "{_save_dir}"
+overwrite = false
+verbose = true
+
+# =============================================================================
+# You can set the priority order for checking data sources.
+# If you don't specify a default priority, Herbie will check each source in the
+# order listed in the model template file. Beware: setting a default priority
+# might prevent you from checking all available sources.
+#
+# priority = ['aws', 'nomads', 'google', 'etc.']

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,13 @@
+import toml
+
+from herbie import default_toml
+
+
+def test_default_toml():
+    # Confirm that default_toml is valid
+    a = toml.loads(default_toml)
+
+    a["default"]["model"] == "hrrr"
+    a["default"]["fxx"] == 0
+    a["default"]["overwrite"] == False
+    a["default"]["verbose"] == True


### PR DESCRIPTION
Fixes #251, #243

This improves the use of Herbie's config file.

1. Load config file if it exists.
1. Create config file if it doesn't exist, and then load it.
1. If file creation fails, then load defaults.