### PR TITLE
Hide curl messages unless verbose

### DIFF
--- a/herbie/core.py
+++ b/herbie/core.py
@@ -920,7 +920,9 @@ class Herbie:
                 else:
                     # ...all other messages are appended to the subset file.
                     curl = f'''curl -s --range {range} "{grib_source}" >> "{outFile}"'''
-                print(curl)
+                
+                if verbose:
+                    print(curl)
                 os.system(curl)
 
             if verbose:


### PR DESCRIPTION
Hi,

I love this project and am currently implementing it in production over at [Pirate Weather](https://pirateweather.net)! It's the perfect tool for simplifying a bunch of initial data download steps, and the subsetting tool has significantly reduced my download sizes.

Submitting this PR to see if you're open to the idea of moving the print statement for a curl subset behind the verbose flag. It produces a ton of logs on my end (180 hours by a couple dozen variables), and I thought it would make sense to have it off by default.