### PR TITLE
Enhancement: New helper functions to find the latest model data, `HerbieLatest` and `HerbieWait`

### DIFF
--- a/docs/user_guide/_bonus_notebooks/Herbie_latest.ipynb
+++ b/docs/user_guide/_bonus_notebooks/Herbie_latest.ipynb
@@ -7,7 +7,9 @@
    "source": [
     "# ⌚ Herbie Latest\n",
     "\n",
-    "A little helper to get the most recent model data. (Not super efficient, but it works)."
+    "A little helper to get the most recent model data. (Not super efficient, but it works).\n",
+    "\n",
+    "> ### Note: this is old. I would advise you use the `HerbieLatest` function instead.\n"
    ]
   },
   {
@@ -82,7 +84,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Latest with a loop"
+    "## Latest with a loop\n"
    ]
   },
   {
@@ -204,7 +206,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Most recent GFS (loop)"
+    "## Most recent GFS (loop)\n"
    ]
   },
   {
@@ -293,26 +295,50 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 27,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "import time\n",
-    "time.sleep()"
+    "## Wait for specific time\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import sleep\n",
+    "import time\n",
+    "\n",
+    "time.sleep(5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Found ┊ model=hrrr ┊ \u001b[3mproduct=sfc\u001b[0m ┊ \u001b[38;2;41;130;13m2024-Jan-19 05:00 UTC\u001b[92m F00\u001b[0m ┊ \u001b[38;2;255;153;0m\u001b[3mGRIB2 @ aws\u001b[0m ┊ \u001b[38;2;255;153;0m\u001b[3mIDX @ aws\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "import time\n",
     "\n",
     "now = pd.Timestamp.utcnow().floor(\"1h\").tz_localize(None)\n",
-    "H = Herbie(now, model='hrrr')\n",
-    "while H.grib is None\n"
+    "attempts = 0\n",
+    "H = Herbie(now, model=\"hrrr\", priority=[\"aws\", \"nomads\"])\n",
+    "while H.grib is None:\n",
+    "    # Try to find file again\n",
+    "    H = Herbie(now, model=\"hrrr\", priority=[\"aws\", \"nomads\"])\n",
+    "\n",
+    "    # Wait 5 seconds\n",
+    "    time.sleep(5)\n",
+    "    attempts += 1\n",
+    "    print(f\"{attempts=}\")"
    ]
   }
  ],

--- a/docs/user_guide/_tutorial_notebooks/index.rst
+++ b/docs/user_guide/_tutorial_notebooks/index.rst
@@ -6,6 +6,7 @@
    :maxdepth: 1
 
    intro.ipynb
+   latest.ipynb
    fast.ipynb
    accessors.ipynb
    demo_map.ipynb

--- a/docs/user_guide/_tutorial_notebooks/latest.ipynb
+++ b/docs/user_guide/_tutorial_notebooks/latest.ipynb
@@ -1,0 +1,186 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Latest Data\n",
+    "\n",
+    "Herbie can help you find the latest model data available with `HerbieLatest` and `HerbieWait`. These are simple helper functions that loops until Herbie finds data.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from herbie import HerbieLatest, HerbieWait"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## `HerbieLatest`\n",
+    "\n",
+    "Herbie can find the latest model grid available. It does this by checking the for data in the most recent time, and then steps back in time a model cycle and checks for that. By default, if data is not found in four attempts, it will return an error.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Found ┊ model=hrrr ┊ \u001b[3mproduct=sfc\u001b[0m ┊ \u001b[38;2;41;130;13m2024-Jan-19 19:00 UTC\u001b[92m F06\u001b[0m ┊ \u001b[38;2;255;153;0m\u001b[3mGRIB2 @ aws\u001b[0m ┊ \u001b[38;2;255;153;0m\u001b[3mIDX @ aws\u001b[0m\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "\u001b[48;2;255;255;255m\u001b[38;2;136;33;27m▌\u001b[0m\u001b[38;2;12;53;118m\u001b[48;2;240;234;210m▌\u001b[38;2;0;0;0m\u001b[1mHerbie\u001b[0m HRRR model \u001b[3msfc\u001b[0m product initialized \u001b[38;2;41;130;13m2024-Jan-19 19:00 UTC\u001b[92m F06\u001b[0m ┊ \u001b[38;2;255;153;0m\u001b[3msource=aws\u001b[0m"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "H = HerbieLatest(model=\"hrrr\", fxx=6)\n",
+    "H"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ Found ┊ model=gfs ┊ \u001b[3mproduct=pgrb2.0p25\u001b[0m ┊ \u001b[38;2;41;130;13m2024-Jan-19 18:00 UTC\u001b[92m F00\u001b[0m ┊ \u001b[38;2;255;153;0m\u001b[3mGRIB2 @ aws\u001b[0m ┊ \u001b[38;2;255;153;0m\u001b[3mIDX @ aws\u001b[0m\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "\u001b[48;2;255;255;255m\u001b[38;2;136;33;27m▌\u001b[0m\u001b[38;2;12;53;118m\u001b[48;2;240;234;210m▌\u001b[38;2;0;0;0m\u001b[1mHerbie\u001b[0m GFS model \u001b[3mpgrb2.0p25\u001b[0m product initialized \u001b[38;2;41;130;13m2024-Jan-19 18:00 UTC\u001b[92m F00\u001b[0m ┊ \u001b[38;2;255;153;0m\u001b[3msource=aws\u001b[0m"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "H = HerbieLatest(model=\"gfs\")\n",
+    "H"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "💔 Did not find ┊ model=hrrr ┊ \u001b[3mproduct=sfc\u001b[0m ┊ \u001b[38;2;41;130;13m2024-Jan-19 19:00 UTC\u001b[92m F100\u001b[0m\n",
+      "💔 Did not find ┊ model=hrrr ┊ \u001b[3mproduct=sfc\u001b[0m ┊ \u001b[38;2;41;130;13m2024-Jan-19 18:00 UTC\u001b[92m F100\u001b[0m\n",
+      "💔 Did not find ┊ model=hrrr ┊ \u001b[3mproduct=sfc\u001b[0m ┊ \u001b[38;2;41;130;13m2024-Jan-19 17:00 UTC\u001b[92m F100\u001b[0m\n",
+      "💔 Did not find ┊ model=hrrr ┊ \u001b[3mproduct=sfc\u001b[0m ┊ \u001b[38;2;41;130;13m2024-Jan-19 16:00 UTC\u001b[92m F100\u001b[0m\n"
+     ]
+    },
+    {
+     "ename": "TimeoutError",
+     "evalue": "Herbie did not find data for the latest time: ║HERBIE╠ HRRR:sfc",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTimeoutError\u001b[0m                              Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[5], line 3\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;66;03m# This will error because there will never been\u001b[39;00m\n\u001b[1;32m      2\u001b[0m \u001b[38;5;66;03m# a lead time of 100 hours.\u001b[39;00m\n\u001b[0;32m----> 3\u001b[0m H \u001b[38;5;241m=\u001b[39m \u001b[43mHerbieLatest\u001b[49m\u001b[43m(\u001b[49m\u001b[43mmodel\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mhrrr\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mfxx\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;241;43m100\u001b[39;49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/GITHUB/Herbie/herbie/latest.py:53\u001b[0m, in \u001b[0;36mHerbieLatest\u001b[0;34m(model, priority, periods, **kwargs)\u001b[0m\n\u001b[1;32m     50\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m H\u001b[38;5;241m.\u001b[39mgrib:\n\u001b[1;32m     51\u001b[0m         \u001b[38;5;28;01mreturn\u001b[39;00m H\n\u001b[0;32m---> 53\u001b[0m \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mTimeoutError\u001b[39;00m(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mHerbie did not find data for the latest time: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mH\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m)\n",
+      "\u001b[0;31mTimeoutError\u001b[0m: Herbie did not find data for the latest time: ║HERBIE╠ HRRR:sfc"
+     ]
+    }
+   ],
+   "source": [
+    "# This will error because there will never been\n",
+    "# a lead time of 100 hours.\n",
+    "H = HerbieLatest(model=\"hrrr\", fxx=100)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# `HerbieWait`\n",
+    "\n",
+    "I don't have the patience to actually try this, but if you want to wait for data to become available, Herbie will use a while loop to wait for data.\n",
+    "\n",
+    "In this example, I've changed the default wait time and interval just to demonstrate. (The error in this is expected, but if you wait long enough it _should_ work.)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "💔 Did not find ┊ model=hrrr ┊ \u001b[3mproduct=sfc\u001b[0m ┊ \u001b[38;2;41;130;13m2024-Jan-19 19:00 UTC\u001b[92m F39\u001b[0m\n",
+      "💔 Did not find ┊ model=hrrr ┊ \u001b[3mproduct=sfc\u001b[0m ┊ \u001b[38;2;41;130;13m2024-Jan-19 19:00 UTC\u001b[92m F39\u001b[0m\n",
+      "💔 Did not find ┊ model=hrrr ┊ \u001b[3mproduct=sfc\u001b[0m ┊ \u001b[38;2;41;130;13m2024-Jan-19 19:00 UTC\u001b[92m F39\u001b[0m\n",
+      "💔 Did not find ┊ model=hrrr ┊ \u001b[3mproduct=sfc\u001b[0m ┊ \u001b[38;2;41;130;13m2024-Jan-19 19:00 UTC\u001b[92m F39\u001b[0m\n",
+      "💔 Did not find ┊ model=hrrr ┊ \u001b[3mproduct=sfc\u001b[0m ┊ \u001b[38;2;41;130;13m2024-Jan-19 19:00 UTC\u001b[92m F39\u001b[0m\n"
+     ]
+    },
+    {
+     "ename": "TimeoutError",
+     "evalue": "Herbie did not find data in time: ║HERBIE╠ HRRR:sfc",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTimeoutError\u001b[0m                              Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[5], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mHerbieWait\u001b[49m\u001b[43m(\u001b[49m\u001b[43mwait_for\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43m10s\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mcheck_interval\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43m1s\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mfxx\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;241;43m39\u001b[39;49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/GITHUB/Herbie/herbie/latest.py:107\u001b[0m, in \u001b[0;36mHerbieWait\u001b[0;34m(model, priority, wait_for, check_interval, **kwargs)\u001b[0m\n\u001b[1;32m    104\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m (pd\u001b[38;5;241m.\u001b[39mTimestamp(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mnow\u001b[39m\u001b[38;5;124m\"\u001b[39m) \u001b[38;5;241m-\u001b[39m timer) \u001b[38;5;241m>\u001b[39m\u001b[38;5;241m=\u001b[39m pd\u001b[38;5;241m.\u001b[39mTimedelta(wait_for):\n\u001b[1;32m    105\u001b[0m         \u001b[38;5;28;01mbreak\u001b[39;00m\n\u001b[0;32m--> 107\u001b[0m \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mTimeoutError\u001b[39;00m(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mHerbie did not find data in time: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mH\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m)\n",
+      "\u001b[0;31mTimeoutError\u001b[0m: Herbie did not find data in time: ║HERBIE╠ HRRR:sfc"
+     ]
+    }
+   ],
+   "source": [
+    "H = HerbieWait(wait_for=\"10s\", check_interval=\"1s\", fxx=39)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "herbie",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/herbie/__init__.py
+++ b/herbie/__init__.py
@@ -194,5 +194,6 @@ if os.getenv("HERBIE_SAVE_DIR"):
     )
 
 from herbie.core import Herbie
-from herbie.fast import FastHerbie, Herbie_latest
+from herbie.fast import FastHerbie
+from herbie.latest import HerbieLatest, HerbieWait
 from herbie.wgrib2 import wgrib2

--- a/herbie/latest.py
+++ b/herbie/latest.py
@@ -53,7 +53,6 @@ def HerbieLatest(
     raise TimeoutError(f"Herbie did not find data for the latest time: {H}")
 
 
-
 def HerbieWait(
     model=config["default"].get("model"),
     priority=["aws", "nomads"],

--- a/herbie/latest.py
+++ b/herbie/latest.py
@@ -1,0 +1,107 @@
+"""Herbie Helpers to get the latest model grid."""
+
+import time
+
+import pandas as pd
+
+from herbie import Herbie, config
+
+
+def HerbieLatest(
+    model=config["default"].get("model"),
+    priority=["aws", "nomads"],
+    periods=4,
+    **kwargs,
+):
+    r"""Find the latest model data.
+
+    Parameters
+    ----------
+    model : str
+        The name of the model.
+    priority : list
+        The sources to look for data.
+
+        The default value `["aws", "nomads"]` was chosen because it is a
+        reasonable priority order for many of the models available from
+        the NODD program (NOAA models like HRRR, GFS, GEFS, etc.) The
+        data for these models will be made available on NOMADS first,
+        but I also know AWS gets the data pretty quick. So, check AWS
+        first, then check NOMADS (because if you make too many downloads
+        from NOMADS your IP address will get blocked.)
+    **kwargs
+        Any other input you want passed to the Herbie class.
+    """
+    if model.lower() in ["hrrr", "rap"]:
+        freq = "1H"
+    else:
+        freq = "6H"
+
+    # Create a list of recent dates to try
+    dates = pd.date_range(
+        pd.Timestamp.utcnow().floor(freq).tz_localize(None),
+        periods=4,
+        freq=f"-{freq}",
+    )
+
+    # Find first existing Herbie object
+    for date in dates:
+        H = Herbie(date=date, model=model, priority=priority, **kwargs)
+        if H.grib:
+            return H
+
+    raise TimeoutError(f"Herbie did not find data for the latest time: {H}")
+
+
+
+def HerbieWait(
+    model=config["default"].get("model"),
+    priority=["aws", "nomads"],
+    wait_for="5min",
+    check_interval="15s",
+    **kwargs,
+):
+    """Wait for the latest model grid to become available.
+
+    Parameters
+    ----------
+    model : str
+        The name of the model.
+    priority : list
+        The sources to look for data.
+
+        The default value `["aws", "nomads"]` was chosen because it is a
+        reasonable priority order for many of the models available from
+        the NODD program (NOAA models like HRRR, GFS, GEFS, etc.) The
+        data for these models will be made available on NOMADS first,
+        but I also know AWS gets the data pretty quick. So, check AWS
+        first, then check NOMADS (because if you make too many downloads
+        from NOMADS your IP address will get blocked.)
+    wait_for : timedelta or Pandas-parsable Timedelta str
+        Length of time Herbie will wait for data.
+    check_every : int (seconds), timedelta, Pandas-parsable Timedelta str
+        Frequency Herbie will look for data again, as a pandas-parsable
+        timedelta string (e.g., '30s') or an int representing seconds.
+    **kwargs
+        Any other input you want passed to the Herbie class.
+    """
+    now = pd.Timestamp.utcnow().floor("1h").tz_localize(None)
+
+    if isinstance(check_interval, str):
+        check_interval = pd.Timedelta(check_interval).total_seconds()
+
+    timer = pd.Timestamp("now")
+
+    H = Herbie(now, model=model, priority=priority, **kwargs)
+
+    while H.grib is None:
+        H = Herbie(now, model=model, priority=priority, **kwargs)
+        if H.grib:
+            return H
+
+        time.sleep(check_interval)
+
+        if (pd.Timestamp("now") - timer) >= pd.Timedelta(wait_for):
+            break
+
+    raise TimeoutError(f"Herbie did not find data in time: {H}")

--- a/herbie/latest.py
+++ b/herbie/latest.py
@@ -95,6 +95,7 @@ def HerbieWait(
     H = Herbie(now, model=model, priority=priority, **kwargs)
 
     while H.grib is None:
+        now = pd.Timestamp.utcnow().floor("1h").tz_localize(None)
         H = Herbie(now, model=model, priority=priority, **kwargs)
         if H.grib:
             return H


### PR DESCRIPTION
Building on the discussion in https://github.com/blaylockbk/Herbie/discussions/272, this PR adds two Herbie helper functions

- `HerbieLatest`
- `HerbieWait`

These functions are simply loop over making a Herbie class until a recent model grid is found. 

`HerbieLatest` will return the most recent model available while `HerbieWait` will wait for the next available. I haven't been patient enough to test that HerbieWait actually works, but I think it should.

These might be helpful to people who need to get the latest real-time model data rather than looking for archived content.

To use, 

```python
from herbie import HerbieLatest

H = HerbieLatest(model='hrrr')
```

(See also the notebook in the documentation `User_Guide>Tutorials>Latest_Data`