### PR TITLE
Check that curl is in system path; warn if it is not

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,6 @@ MANIFEST
 $TMPDIR/
 
 $TMPDIR/
+data/
 
 herbie/_version.py

--- a/herbie/core.py
+++ b/herbie/core.py
@@ -89,7 +89,9 @@ wgrib2 = which("wgrib2")
 # Location of curl command. Required to download data.
 curl = which("curl")
 if curl is None:
-    warnings.warn("Curl is not in system Path. Herbie won't be able to download GRIB files.")
+    warnings.warn(
+        "Curl is not in system Path. Herbie won't be able to download GRIB files."
+    )
 
 
 def wgrib2_idx(grib2filepath):

--- a/herbie/core.py
+++ b/herbie/core.py
@@ -325,15 +325,18 @@ class Herbie:
         else:
             HELP = "│"
         print(
-            "╭─Herbie────────────────────────────────\n"
+            "╭─ Herbie ────────────────────────────────\n"
             f"│ Help for model='{self.model}'\n"
-            f"│ \n"
-            f"│ {self.DESCRIPTION}\n"
-            f"│ {str(self.DETAILS).replace(',', '\n│')}\n"
-            f"│ \n"
+            "│ \n"
+            f"│ {self.DESCRIPTION}"
+        )
+        for key, value in self.DETAILS.items():
+            print(f"│  {key}: {value}")
+        print(
+            "│ \n"
             f"│ {HELP}\n"
-            f"│ \n"
-            "╰───────────────────────────────────────\n"
+            "│ \n"
+            "╰─────────────────────────────────────────\n"
         )
 
     def tell_me_everything(self):
@@ -666,7 +669,7 @@ class Herbie:
             df["reference_time"] = pd.to_datetime(
                 df.reference_time, format="d=%Y%m%d%H"
             )
-            df["valid_time"] = df["reference_time"] + pd.to_timedelta(f"{self.fxx}H")
+            df["valid_time"] = df["reference_time"] + pd.to_timedelta(f"{self.fxx}h")
             df["start_byte"] = df["start_byte"].astype(int)
             df["end_byte"] = df["start_byte"].shift(-1) - 1
             df["range"] = df.apply(

--- a/herbie/core.py
+++ b/herbie/core.py
@@ -324,20 +324,16 @@ class Herbie:
             HELP = self.HELP.strip().replace("\n", "\n│ ")
         else:
             HELP = "│"
-        print(
-            "╭─ Herbie ────────────────────────────────\n"
-            f"│ Help for model='{self.model}'\n"
-            "│ \n"
-            f"│ {self.DESCRIPTION}"
-        )
+        print("╭─ Herbie ────────────────────────────────")
+        print(f"│ Help for model='{self.model}'")
+        print("│ ")
+        print(f"│ {self.DESCRIPTION}")
         for key, value in self.DETAILS.items():
             print(f"│  {key}: {value}")
-        print(
-            "│ \n"
-            f"│ {HELP}\n"
-            "│ \n"
-            "╰─────────────────────────────────────────\n"
-        )
+        print("│")
+        print(f"│ {HELP}")
+        print("│")
+        print("╰─────────────────────────────────────────")
 
     def tell_me_everything(self):
         """Print all the attributes of the Herbie object."""

--- a/herbie/core.py
+++ b/herbie/core.py
@@ -83,8 +83,13 @@ except:
 
 log = logging.getLogger(__name__)
 
-# Location of wgrib2 command, if it exists
+# Location of wgrib2 command, if it exists. Required to make missing idx files.
 wgrib2 = which("wgrib2")
+
+# Location of curl command. Required to download data.
+curl = which("curl")
+if curl is None:
+    warnings.warn("Curl is not in system Path. Herbie won't be able to download GRIB files.")
 
 
 def wgrib2_idx(grib2filepath):


### PR DESCRIPTION
Curl is a Herbie requirement because it is used to download subset grib files. Importing the Herbie class will now check that curl is in the system Path. If not, a warning will display.

Also include fix due to changes in https://github.com/pandas-dev/pandas/issues/52536