### PR TITLE
Improve Herbie's model templates

### DIFF
--- a/herbie/core.py
+++ b/herbie/core.py
@@ -266,16 +266,6 @@ class Herbie:
         # (see https://stackoverflow.com/a/7936588/2383070 for what I'm doing here)
         getattr(model_templates, self.model).template(self)
 
-        if product is None:
-            # The user didn't specify a product, so let's use the first
-            # product in the model template.
-            self.product = list(self.PRODUCTS)[0]
-            log.info(f'`product` not specified. Will use "{self.product}".')
-            # We need to rerun this so the sources have the new product value.
-            getattr(model_templates, self.model).template(self)
-
-        self.product_description = self.PRODUCTS[self.product]
-
         # Specify the suffix for the inventory index files.
         # Default value is `.grib2.idx`, but some have weird suffix,
         # like archived RAP on NCEI are `.grb2.inv`.
@@ -371,11 +361,9 @@ class Herbie:
             self.model = "hrrrak"
 
         _models = {m for m in dir(model_templates) if not m.startswith("__")}
-        _products = set(self.PRODUCTS)
 
         assert self.date < datetime.utcnow(), "🔮 `date` cannot be in the future."
         assert self.model in _models, f"`model` must be one of {_models}"
-        assert self.product in _products, f"`product` must be one of {_products}"
 
         if isinstance(self.IDX_SUFFIX, str):
             self.IDX_SUFFIX = [self.IDX_SUFFIX]

--- a/herbie/models/ecmwf.py
+++ b/herbie/models/ecmwf.py
@@ -19,20 +19,41 @@ from datetime import datetime
 
 
 class ifs:
+    """Template for ECMWF Integrated Forecast System (IFS)."""
+
     def template(self):
-        # Allow a user to select the deprecated 0p4-beta resolution,
-        # but default to the 0p25 product if resolution is not specified.
-        # Sounds like the 0p4-beta product will be deprecated in May 2024.
+        # --------
+        # Metadata
+        self.DESCRIPTION = "ECMWF Open Data - Integrated Forecast System"
+        self.IDX_SUFFIX = [".index"]
+        self.IDX_STYLE = "eccodes"  # 'wgrib2' or 'eccodes'
+        self.SOURCE_LINKS = {
+            "azure": "",
+            "aws": "",
+            "ecmwf": "https://confluence.ecmwf.int/display/DAC/ECMWF+open+data%3A+real-time+forecasts+from+IFS+and+AIFS",
+        }
+
+        # ----------
+        # Validation
+
+        # IFS is run every 6 hours.
+        _hours = range(0, 24, 6)
+        if self.date.hour not in _hours:
+            raise ValueError(f"Request date's hour must be one of {list(_hours)}")
+
+        # ECMWF provided 0.4 degree data until 2 February 2024 when they
+        # started publishing 0.25 degree data. The 0p4-beta product will
+        # be deprecated in May 2024.
+        _resolutions = ["0p25", "0p4-beta"]
         if not hasattr(self, "resolution") or self.resolution is None:
             self.resolution = "0p25"
             if self.date < datetime(2024, 2, 1):
                 self.resolution = "0p4-beta"
+        elif self.resolution not in set(_resolutions):
+            raise ValueError(f"`resolution` must be one of {list(_resolutions)}")
 
-        self.DESCRIPTION = "ECMWF Open Data - Integrated Forecast System"
-        self.DETAILS = {
-            "ECMWF": "https://confluence.ecmwf.int/display/DAC/ECMWF+open+data%3A+real-time+forecasts+from+IFS+and+AIFS",
-        }
-        self.PRODUCTS = {
+        # IFS produces the following output products.
+        _products = {
             "oper": "operational high-resolution forecast, atmospheric fields",
             "enfo": "ensemble forecast, atmospheric fields",
             "wave": "wave forecasts",
@@ -41,6 +62,13 @@ class ifs:
             "scwv": "short cut-off high-resolution forecast, ocean wave fields (also known as high-frequency products)",
             "mmsf": "multi-model seasonal forecasts fields from the ECMWF model only.",
         }
+        if not hasattr(self, "product") or self.product is None:
+            self.product = list(_products)[0]
+        elif self.product not in set(_products):
+            raise ValueError(f"`product` must be one of {list(_products)}")
+
+        # -----------------
+        # Build Source URLs
 
         # example file
         # https://data.ecmwf.int/forecasts/20240229/00z/ifs/0p25/oper/20240229000000-0h-oper-fc.grib2
@@ -62,30 +90,60 @@ class ifs:
                 f"/{self.date:%Y%m%d%H%M%S}-{self.fxx}h-{self.product}-{product_suffix}.grib2"
             )
 
-        # If user asks for 'oper' or 'wave', still look for data in scda and waef for the short cut-off high resolution forecast.
         self.SOURCES = {
             "azure": f"https://ai4edataeuwest.blob.core.windows.net/ecmwf/{post_root}",
-            "azure-scda": f"https://ai4edataeuwest.blob.core.windows.net/ecmwf/{post_root.replace('oper', 'scda')}",
-            "azure-waef": f"https://ai4edataeuwest.blob.core.windows.net/ecmwf/{post_root.replace('wave', 'waef')}",
             "aws": f"https://ecmwf-forecasts.s3.eu-central-1.amazonaws.com/{post_root}",
             "ecmwf": f"https://data.ecmwf.int/forecasts/{post_root}",
         }
-        self.IDX_SUFFIX = [".index"]
-        self.IDX_STYLE = "eccodes"  # 'wgrib2' or 'eccodes'
+
+        # If user asks for 'oper' or 'wave', still look for data in scda
+        # and waef for the short cut-off high resolution forecast.
+        self.SOURCES |= {
+            "azure-scda": f"https://ai4edataeuwest.blob.core.windows.net/ecmwf/{post_root.replace('oper', 'scda')}",
+            "azure-waef": f"https://ai4edataeuwest.blob.core.windows.net/ecmwf/{post_root.replace('wave', 'waef')}",
+            "aws-scda": f"https://ecmwf-forecasts.s3.eu-central-1.amazonaws.com/{post_root.replace('oper', 'scda')}",
+            "aws-waef": f"https://ecmwf-forecasts.s3.eu-central-1.amazonaws.com/{post_root.replace('wave', 'waef')}",
+        }
+
         self.LOCALFILE = f"{self.get_remoteFileName}"
 
 
 class aifs:
+    """Template for ECMWF Artificial Intelligence Integrated Forecast System (AIFS)."""
+
     def template(self):
+        # --------
+        # Metadata
         self.DESCRIPTION = (
-            "ECMWF Open Data - Artificial Inteligence Integrated Forecast System"
+            "ECMWF Open Data - Artificial Intelligence Integrated Forecast System"
         )
-        self.DETAILS = {
-            "ECMWF": "https://confluence.ecmwf.int/display/DAC/ECMWF+open+data%3A+real-time+forecasts+from+IFS+and+AIFS",
+        self.IDX_SUFFIX = [".index"]
+        self.IDX_STYLE = "eccodes"  # 'wgrib2' or 'eccodes'
+        self.SOURCE_LINKS = {
+            "azure": "",
+            "aws": "",
+            "ecmwf": "https://confluence.ecmwf.int/display/DAC/ECMWF+open+data%3A+real-time+forecasts+from+IFS+and+AIFS",
         }
-        self.PRODUCTS = {
+
+        # ----------
+        # Validation
+
+        # AIFS is run every 6 hours.
+        _hours = range(0, 24, 6)
+        if self.date.hour not in _hours:
+            raise ValueError(f"Request date's hour must be one of {list(_hours)}")
+
+        # AIFS produces the following output products.
+        _products = {
             "oper": "operational high-resolution forecast, atmospheric fields",
         }
+        if not hasattr(self, "product") or self.product is None:
+            self.product = list(_products)[0]
+        elif self.product not in set(_products):
+            raise ValueError(f"`product` must be one of {list(_products)}")
+
+        # -----------------
+        # Build Source URLs
 
         # example file
         # https://data.ecmwf.int/forecasts/20240229/00z/aifs/0p25/oper/20240229000000-0h-oper-fc.grib2
@@ -102,6 +160,5 @@ class aifs:
             "aws": f"https://ecmwf-forecasts.s3.eu-central-1.amazonaws.com/{post_root}",
             "ecmwf": f"https://data.ecmwf.int/forecasts/{post_root}",
         }
-        self.IDX_SUFFIX = [".index"]
-        self.IDX_STYLE = "eccodes"  # 'wgrib2' or 'eccodes'
+
         self.LOCALFILE = f"{self.get_remoteFileName}"


### PR DESCRIPTION
The goal of these changes to the model templates is to help improve maintainability in the model templates.

- Do user validation to the model template rather than in the Herbie class. This will be nice since models sometimes need unique conditions or arguments that are not needed for other models.
- Control the Herbie arguments from the model template, and alert the user when wrong input is given.