### PR TITLE
Adding Ability to Download NBM QMD Data

### DIFF
--- a/herbie/models/nbm.py
+++ b/herbie/models/nbm.py
@@ -27,7 +27,7 @@ class nbm:
 
 class nbmqmd:
     def template(self):
-        self.DESCRIPTION = "National Blend of Models"
+        self.DESCRIPTION = "National Blend of Models - QMD"
         self.DETAILS = {
             "NOMADS product description": "https://www.nco.ncep.noaa.gov/pmb/products/blend/",
             "AWS Registry": "https://registry.opendata.aws/noaa-nbm/",

--- a/herbie/models/nbm.py
+++ b/herbie/models/nbm.py
@@ -23,3 +23,26 @@ class nbm:
             "aws": f"https://noaa-nbm-grib2-pds.s3.amazonaws.com/blend.{self.date:%Y%m%d/%H}/core/blend.t{self.date:%H}z.core.f{self.fxx:03d}.{self.product}.grib2",
         }
         self.LOCALFILE = f"{self.get_remoteFileName}"
+
+
+class nbmqmd:
+    def template(self):
+        self.DESCRIPTION = "National Blend of Models"
+        self.DETAILS = {
+            "NOMADS product description": "https://www.nco.ncep.noaa.gov/pmb/products/blend/",
+            "AWS Registry": "https://registry.opendata.aws/noaa-nbm/",
+            "NWS National Blend of Models Home": "https://www.weather.gov/mdl/nbm_home",
+            "MDL NBM Page": "https://vlab.noaa.gov/web/mdl/nbm",
+        }
+        self.PRODUCTS = {
+            "ak": "Alaska; 13-km resolution",
+            "co": "CONUS 13-km resolution",
+            "gu": "Guam 13-km resolution",
+            "hi": "Hawaii 13-km resolution",
+            "pr": "Puerto Rico 13-km resolution",
+        }
+        self.SOURCES = {
+            "nomads": f"https://nomads.ncep.noaa.gov/pub/data/nccf/com/blend/prod/blend.{self.date:%Y%m%d/%H}/qmd/blend.t{self.date:%H}z.qmd.f{self.fxx:03d}.{self.product}.grib2",
+            "aws": f"https://noaa-nbm-grib2-pds.s3.amazonaws.com/blend.{self.date:%Y%m%d/%H}/qmd/blend.t{self.date:%H}z.qmd.f{self.fxx:03d}.{self.product}.grib2",
+        }
+        self.LOCALFILE = f"{self.get_remoteFileName}"


### PR DESCRIPTION
This pull request is to cover the request in #300 to allow for downloading NBM QMD data. I kept is simple and created an extra "nbmqmd" class to handle the switch between the two datasets, with the only change between them being the SOURCES URLs. 

A couple items of note: The QMD data is only available for the 00Z/06Z/12Z/18Z NBM runs and arrives about 6-7 hours after the valid time of the run.