### PR TITLE
Optional dependencies

### DIFF
--- a/.github/workflows/tests-python.yml
+++ b/.github/workflows/tests-python.yml
@@ -73,19 +73,19 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           pip3 install --requirement=requirements-test.txt
-          pip3 install --editable=.
+          pip3 install --editable='.[extras]'
 
       - name: Install project (macOS)
         if: runner.os == 'macOS'
         run: |
           pip3 install --break-system-packages --requirement=requirements-test.txt
-          pip3 install --break-system-packages --editable=.
+          pip3 install --break-system-packages --editable='.[extras]'
 
       - name: Install project (Windows)
         if: runner.os == 'Windows'
         run: |
           pip3 install --requirement=requirements-test.txt
-          pip3 install --editable=.
+          pip3 install --editable='.[extras]'
 
       - name: Run tests
         env:

--- a/docs/user_guide/install.md
+++ b/docs/user_guide/install.md
@@ -18,7 +18,6 @@ Herbie is published on PyPI and you can install it with pip, _but_ it requires s
 
 - Python 3.9+
 - cURL
-- [cfgrib](https://github.com/ecmwf/cfgrib), which requires **_eccodes_** (most easily installed with conda)
 - _Optional:_ wgrib2
 - _Optional:_ [Carpenter Workshop](https://github.com/blaylockbk/Carpenter_Workshop)
 

--- a/docs/user_guide/install.md
+++ b/docs/user_guide/install.md
@@ -28,7 +28,15 @@ When those are installed within your environment, _then_ you can install Herbie 
 pip install herbie-data
 ```
 
-or
+To install the full functionality in the library which includes
+[xarray accessors](https://github.com/blaylockbk/Herbie/blob/main/herbie/accessors.py) for plotting and data manipulation please install the "extras" dependencies:
+
+```bash
+# Install last published version
+pip install 'herbie-data[extras]'
+```
+
+The code can also be installed directly from github.
 
 ```bash
 # Install current main branch

--- a/herbie/accessors.py
+++ b/herbie/accessors.py
@@ -22,7 +22,6 @@ import xarray as xr
 from pyproj import CRS
 
 import herbie
-from herbie.misc import try_import
 
 
 _level_units = dict(
@@ -96,12 +95,30 @@ class HerbieAccessor:
     def __init__(self, xarray_obj):
         self._obj = xarray_obj
         self._center = None
-        try_import("metpy")
-        try_import("cartopy.crs", as_name="ccrs")
-        try_import("shapely")
-        try_import("shapely.geometry", from_list=["Point", "MultiPoint", "Polygon"])
-        try_import("sklearn.neighbors", from_list=["BallTree"])
-        try_import("matplotlib.pyplot", as_name="plt")
+        try:
+            import metpy
+            import matplotlib.pyplot as plt
+        except ModuleNotFoundError:
+            warnings.warn(
+                "metpy is an 'extra' requirement, please use "
+                "`pip install 'herbie-data[extras]'` for the full functionality."
+        )
+        try:
+            import cartopy.crs as ccrs
+            import shapely
+            from shapely.geometry import MultiPoint, Point, Polygon
+        except ModuleNotFoundError:
+            warnings.warn(
+                "cartopy is an 'extra' requirements, please use "
+                "`pip install 'herbie-data[extras]'` for the full functionality."
+            )
+        try:
+            from sklearn.neighbors import BallTree
+        except ModuleNotFoundError:
+            warnings.warn(
+                "sklearn is an 'extra' requirement, please use "
+                "`pip install 'herbie-data[extras]'` for the full functionality."
+            )
 
     @property
     def center(self):

--- a/herbie/accessors.py
+++ b/herbie/accessors.py
@@ -151,6 +151,9 @@ class HerbieAccessor:
     @functools.cached_property
     def polygon(self):
         """Get a polygon of the domain boundary."""
+        from shapely.geometry import Polygon
+        import cartopy.crs as ccrs
+
         ds = self._obj
 
         LON = ds.longitude.data
@@ -497,6 +500,10 @@ class HerbieAccessor:
             - Or possibly scipy BallTree method.
 
         """
+        import cartopy.crs as ccrs
+        import shapely
+        from shapely.geometry import MultiPoint, Point
+
         warnings.warn(
             "The accessor `ds.herbie.nearest_points` is deprecated in "
             "favor of the `ds.herbie.pick_points` which uses the "
@@ -599,6 +606,7 @@ class HerbieAccessor:
             print(
                 "`pip install git+https://github.com/blaylockbk/Carpenter_Workshop.git`"
             )
+        import matplotlib.pyplot as plt
 
         ds = self._obj
 

--- a/herbie/accessors.py
+++ b/herbie/accessors.py
@@ -95,24 +95,6 @@ class HerbieAccessor:
     def __init__(self, xarray_obj):
         self._obj = xarray_obj
         self._center = None
-        # Optional dependencies
-        try:
-            import metpy
-            import matplotlib.pyplot as plt
-        except ModuleNotFoundError:
-            raise ModuleNotFoundError(
-                "metpy is an 'extra' requirement, please use "
-                "`pip install 'herbie-data[extras]'` for the full functionality."
-        )
-        try:
-            import cartopy.crs as ccrs
-            import shapely
-            from shapely.geometry import MultiPoint, Point, Polygon
-        except ModuleNotFoundError:
-            raise ModuleNotFoundError(
-                "cartopy is an 'extra' requirements, please use "
-                "`pip install 'herbie-data[extras]'` for the full functionality."
-            )
 
     @property
     def center(self):
@@ -138,6 +120,14 @@ class HerbieAccessor:
             An xarray.Dataset from a GRIB2 file opened by the cfgrib engine.
 
         """
+        try:
+            import metpy
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError(
+                "metpy is an 'extra' requirement, please use "
+                "`pip install 'herbie-data[extras]'` for the full functionality."
+            )
+
         ds = self._obj
 
         # Get variables that have dimensions
@@ -151,8 +141,14 @@ class HerbieAccessor:
     @functools.cached_property
     def polygon(self):
         """Get a polygon of the domain boundary."""
-        from shapely.geometry import Polygon
-        import cartopy.crs as ccrs
+        try:
+            import cartopy.crs as ccrs
+            from shapely.geometry import Polygon
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError(
+                "cartopy is an 'extra' requirements, please use "
+                "`pip install 'herbie-data[extras]'` for the full functionality."
+            )
 
         ds = self._obj
 
@@ -260,16 +256,16 @@ class HerbieAccessor:
         dimension.
         >>> dsp = dsp.swap_dims({"point": "point_stid"})
         """
+        try:
+            from sklearn.neighbors import BallTree
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError(
+                "scikit-learn is an 'extra' requirement, please use "
+                "`pip install 'herbie-data[extras]'` for the full functionality."
+            )
 
         def plant_tree(save_pickle=None):
             """Grow a new BallTree object from seedling."""
-            try:
-                from sklearn.neighbors import BallTree
-            except ModuleNotFoundError:
-                raise ModuleNotFoundError(
-                    "scikit-learn is an 'extra' requirement, please use "
-                    "`pip install 'herbie-data[extras]'` for the full functionality."
-                )
             timer = pd.Timestamp("now")
             print("INFO: 🌱 Growing new BallTree...", end="")
             tree = BallTree(np.deg2rad(df_grid), metric="haversine")
@@ -500,9 +496,15 @@ class HerbieAccessor:
             - Or possibly scipy BallTree method.
 
         """
-        import cartopy.crs as ccrs
-        import shapely
-        from shapely.geometry import MultiPoint, Point
+        try:
+            import cartopy.crs as ccrs
+            import shapely
+            from shapely.geometry import MultiPoint, Point
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError(
+                "cartopy is an 'extra' requirements, please use "
+                "`pip install 'herbie-data[extras]'` for the full functionality."
+            )
 
         warnings.warn(
             "The accessor `ds.herbie.nearest_points` is deprecated in "
@@ -596,6 +598,17 @@ class HerbieAccessor:
         # https://github.com/blaylockbk/Carpenter_Workshop
 
         try:
+            import cartopy.crs as ccrs
+            import matplotlib.pyplot as plt
+            import shapely
+            from shapely.geometry import MultiPoint, Point, Polygon
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError(
+                "cartopy is an 'extra' requirements, please use "
+                "`pip install 'herbie-data[extras]'` for the full functionality."
+            )
+
+        try:
             from paint.radar import cm_reflectivity
             from paint.radar2 import cm_reflectivity
             from paint.standard2 import cm_dpt, cm_pcp, cm_rh, cm_tmp, cm_wind
@@ -606,7 +619,6 @@ class HerbieAccessor:
             print(
                 "`pip install git+https://github.com/blaylockbk/Carpenter_Workshop.git`"
             )
-        import matplotlib.pyplot as plt
 
         ds = self._obj
 

--- a/herbie/accessors.py
+++ b/herbie/accessors.py
@@ -23,32 +23,6 @@ from pyproj import CRS
 
 import herbie
 
-# Optional dependencies
-try:
-    import metpy
-    import matplotlib.pyplot as plt
-except ModuleNotFoundError:
-    warnings.warn(
-        "metpy is an 'extra' requirement, please use "
-        "`pip install 'herbie-data[extras]'` for the full functionality."
-)
-try:
-    import cartopy.crs as ccrs
-    import shapely
-    from shapely.geometry import MultiPoint, Point, Polygon
-except ModuleNotFoundError:
-    warnings.warn(
-        "cartopy is an 'extra' requirements, please use "
-        "`pip install 'herbie-data[extras]'` for the full functionality."
-    )
-try:
-    from sklearn.neighbors import BallTree
-except ModuleNotFoundError:
-    warnings.warn(
-        "scikit-learn is an 'extra' requirement, please use "
-        "`pip install 'herbie-data[extras]'` for the full functionality."
-    )
-
 
 _level_units = dict(
     adiabaticCondensation="adiabatic condensation",
@@ -121,6 +95,24 @@ class HerbieAccessor:
     def __init__(self, xarray_obj):
         self._obj = xarray_obj
         self._center = None
+        # Optional dependencies
+        try:
+            import metpy
+            import matplotlib.pyplot as plt
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError(
+                "metpy is an 'extra' requirement, please use "
+                "`pip install 'herbie-data[extras]'` for the full functionality."
+        )
+        try:
+            import cartopy.crs as ccrs
+            import shapely
+            from shapely.geometry import MultiPoint, Point, Polygon
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError(
+                "cartopy is an 'extra' requirements, please use "
+                "`pip install 'herbie-data[extras]'` for the full functionality."
+            )
 
     @property
     def center(self):
@@ -268,6 +260,13 @@ class HerbieAccessor:
 
         def plant_tree(save_pickle=None):
             """Grow a new BallTree object from seedling."""
+            try:
+                from sklearn.neighbors import BallTree
+            except ModuleNotFoundError:
+                raise ModuleNotFoundError(
+                    "scikit-learn is an 'extra' requirement, please use "
+                    "`pip install 'herbie-data[extras]'` for the full functionality."
+                )
             timer = pd.Timestamp("now")
             print("INFO: 🌱 Growing new BallTree...", end="")
             tree = BallTree(np.deg2rad(df_grid), metric="haversine")

--- a/herbie/accessors.py
+++ b/herbie/accessors.py
@@ -23,6 +23,32 @@ from pyproj import CRS
 
 import herbie
 
+# Optional dependencies
+try:
+    import metpy
+    import matplotlib.pyplot as plt
+except ModuleNotFoundError:
+    warnings.warn(
+        "metpy is an 'extra' requirement, please use "
+        "`pip install 'herbie-data[extras]'` for the full functionality."
+)
+try:
+    import cartopy.crs as ccrs
+    import shapely
+    from shapely.geometry import MultiPoint, Point, Polygon
+except ModuleNotFoundError:
+    warnings.warn(
+        "cartopy is an 'extra' requirements, please use "
+        "`pip install 'herbie-data[extras]'` for the full functionality."
+    )
+try:
+    from sklearn.neighbors import BallTree
+except ModuleNotFoundError:
+    warnings.warn(
+        "scikit-learn is an 'extra' requirement, please use "
+        "`pip install 'herbie-data[extras]'` for the full functionality."
+    )
+
 
 _level_units = dict(
     adiabaticCondensation="adiabatic condensation",
@@ -95,30 +121,6 @@ class HerbieAccessor:
     def __init__(self, xarray_obj):
         self._obj = xarray_obj
         self._center = None
-        try:
-            import metpy
-            import matplotlib.pyplot as plt
-        except ModuleNotFoundError:
-            warnings.warn(
-                "metpy is an 'extra' requirement, please use "
-                "`pip install 'herbie-data[extras]'` for the full functionality."
-        )
-        try:
-            import cartopy.crs as ccrs
-            import shapely
-            from shapely.geometry import MultiPoint, Point, Polygon
-        except ModuleNotFoundError:
-            warnings.warn(
-                "cartopy is an 'extra' requirements, please use "
-                "`pip install 'herbie-data[extras]'` for the full functionality."
-            )
-        try:
-            from sklearn.neighbors import BallTree
-        except ModuleNotFoundError:
-            warnings.warn(
-                "sklearn is an 'extra' requirement, please use "
-                "`pip install 'herbie-data[extras]'` for the full functionality."
-            )
 
     @property
     def center(self):

--- a/herbie/accessors.py
+++ b/herbie/accessors.py
@@ -15,18 +15,15 @@ import re
 import warnings
 from pathlib import Path
 
-import cartopy.crs as ccrs
-import metpy  # * Needed for metpy accessor  # noqa: F401
 import numpy as np
 import pandas as pd
 import pygrib
-import shapely
 import xarray as xr
 from pyproj import CRS
-from shapely.geometry import MultiPoint, Point, Polygon
-from sklearn.neighbors import BallTree
 
 import herbie
+from herbie.misc import try_import
+
 
 _level_units = dict(
     adiabaticCondensation="adiabatic condensation",
@@ -99,6 +96,12 @@ class HerbieAccessor:
     def __init__(self, xarray_obj):
         self._obj = xarray_obj
         self._center = None
+        try_import("metpy")
+        try_import("cartopy.crs", as_name="ccrs")
+        try_import("shapely")
+        try_import("shapely.geometry", from_list=["Point", "MultiPoint", "Polygon"])
+        try_import("sklearn.neighbors", from_list=["BallTree"])
+        try_import("matplotlib.pyplot", as_name="plt")
 
     @property
     def center(self):
@@ -566,7 +569,6 @@ class HerbieAccessor:
         """
         # From Carpenter_Workshop:
         # https://github.com/blaylockbk/Carpenter_Workshop
-        import matplotlib.pyplot as plt
 
         try:
             from paint.radar import cm_reflectivity

--- a/herbie/hrrr_zarr.py
+++ b/herbie/hrrr_zarr.py
@@ -12,12 +12,10 @@ The directory structure is very different from the GRIB2 format.
 """
 
 import datetime
-
+import warnings
 import pandas as pd
 import s3fs
 import xarray as xr
-
-from herbie.misc import try_import
 
 
 def load_dataset(urls):
@@ -27,7 +25,13 @@ def load_dataset(urls):
     and latitude/longitude. We also promote the "time" attribute to a coordinate
     so that combining the datasets for each hour will work later on.
     """
-    try_import("cartopy.crs", as_name="ccrs")
+    try:
+        import cartopy.crs as ccrs
+    except ModuleNotFoundError:
+        warnings.warn(
+            "cartopy is an 'extra' requirement, please use "
+            "`pip install 'herbie-data[extras]'` for the full functionality."
+    )
 
     projection = ccrs.LambertConformal(
         central_longitude=262.5,

--- a/herbie/hrrr_zarr.py
+++ b/herbie/hrrr_zarr.py
@@ -12,7 +12,6 @@ The directory structure is very different from the GRIB2 format.
 """
 
 import datetime
-import warnings
 import pandas as pd
 import s3fs
 import xarray as xr
@@ -28,7 +27,7 @@ def load_dataset(urls):
     try:
         import cartopy.crs as ccrs
     except ModuleNotFoundError:
-        warnings.warn(
+        raise ModuleNotFoundError(
             "cartopy is an 'extra' requirement, please use "
             "`pip install 'herbie-data[extras]'` for the full functionality."
     )

--- a/herbie/hrrr_zarr.py
+++ b/herbie/hrrr_zarr.py
@@ -13,10 +13,11 @@ The directory structure is very different from the GRIB2 format.
 
 import datetime
 
-import cartopy.crs as ccrs
 import pandas as pd
 import s3fs
 import xarray as xr
+
+from herbie.misc import try_import
 
 
 def load_dataset(urls):
@@ -26,6 +27,8 @@ def load_dataset(urls):
     and latitude/longitude. We also promote the "time" attribute to a coordinate
     so that combining the datasets for each hour will work later on.
     """
+    try_import("cartopy.crs", as_name="ccrs")
+
     projection = ccrs.LambertConformal(
         central_longitude=262.5,
         central_latitude=38.5,

--- a/herbie/misc.py
+++ b/herbie/misc.py
@@ -18,6 +18,17 @@
   ██  ██  ██  ██  ██  ██  ██  ██  ██  ██  ██  ██  ██  ██  ██  ██  ██  ██
 """
 
+import warnings
+
+try:
+    import matplotlib.pyplot as plt
+    import matplotlib.patheffects as path_effects
+except ModuleNotFoundError:
+    warnings.warn(
+        "matplotlib is an 'extra' requirement, please use "
+        "`pip install 'herbie-data[extras]'` for the full functionality."
+)
+
 
 class hc:
     """Herbie Color Pallette"""
@@ -82,47 +93,6 @@ class ANSI:
     """
 
 
-def try_import(module_name: str, as_name: str = None, from_list: list = []):
-    """Attempt to import an object, and if it fails, provide a helpful message.
-
-    Parameters
-    ----------
-    module_name : str
-        The name of the module to import.
-    as_name : str
-        Name to import the module as, by default the module name.
-    from_list : list
-        List of attributes to import from the module.
-
-    Examples
-    --------
-    >>> try_import("metpy")
-    >>> try_import("cartopy.crs", as_name="ccrs")
-    >>> try_import("shapely.geometry", from_list=["Point", "MultiPoint", "Polygon"])
-
-    """
-    import warnings
-    import inspect
-    from importlib import import_module
-    namespace = inspect.stack()[1][0].f_globals # Update the globals of the calling function
-    try:
-        module = import_module(module_name)
-        if not from_list:
-            as_name = as_name or module_name
-            namespace[as_name] = module
-        else:
-            for attr in from_list:
-                namespace[attr] = getattr(module, attr)
-    except ModuleNotFoundError:
-        warnings.warn(
-            f"{module_name} is an 'extra' requirement for herbie-data. Please install "
-            "with `pip install 'herbie-data[extras]'` for the full functionality."
-        )
-        return None
-    except AttributeError as err:
-        raise ImportError(f"Cannot import {attr} from {module_name}") from err
-
-
 def rich_herbie():
     """
     Returns "▌▌Herbie" with rich colors (if rich is installed).
@@ -160,8 +130,6 @@ def print_rich(H):
 
 def HerbieLogo(white_line=False):
     """Logo of Herbie The Love Bug"""
-    try_import("matplotlib.pyplot", as_name="plt")
-
     plt.figure(figsize=[5, 5], facecolor=hc.tan)
 
     plt.axis([-10, 10, -10, 10])
@@ -211,9 +179,6 @@ def HerbieLogo2(white_line=False, text_color="tan", text_stroke="black"):
     >>> ax = HerbieLogo2(text_color='tan')
     >>> plt.savefig('Herbie_transparent_tan.svg', bbox_inches="tight", transparent=True)
     """
-    try_import("matplotlib.pyplot", as_name="plt")
-    try_import("matplotlib.patheffects", as_name="path_effects")
-
     plt.figure(figsize=[5, 3], facecolor=hc.tan)
 
     plt.axis([1.5, 20, -10, 10])

--- a/herbie/misc.py
+++ b/herbie/misc.py
@@ -82,6 +82,47 @@ class ANSI:
     """
 
 
+def try_import(module_name: str, as_name: str = None, from_list: list = []):
+    """Attempt to import an object, and if it fails, provide a helpful message.
+
+    Parameters
+    ----------
+    module_name : str
+        The name of the module to import.
+    as_name : str
+        Name to import the module as, by default the module name.
+    from_list : list
+        List of attributes to import from the module.
+
+    Examples
+    --------
+    >>> try_import("metpy")
+    >>> try_import("cartopy.crs", as_name="ccrs")
+    >>> try_import("shapely.geometry", from_list=["Point", "MultiPoint", "Polygon"])
+
+    """
+    import warnings
+    import inspect
+    from importlib import import_module
+    namespace = inspect.stack()[1][0].f_globals # Update the globals of the calling function
+    try:
+        module = import_module(module_name)
+        if not from_list:
+            as_name = as_name or module_name
+            namespace[as_name] = module
+        else:
+            for attr in from_list:
+                namespace[attr] = getattr(module, attr)
+    except ModuleNotFoundError:
+        warnings.warn(
+            f"{module_name} is an 'extra' requirement for herbie-data. Please install "
+            "with `pip install 'herbie-data[extras]'` for the full functionality."
+        )
+        return None
+    except AttributeError as err:
+        raise ImportError(f"Cannot import {attr} from {module_name}") from err
+
+
 def rich_herbie():
     """
     Returns "▌▌Herbie" with rich colors (if rich is installed).
@@ -110,7 +151,7 @@ def print_rich(H):
             f"[rgb(41, 130, 13)]F{H.fxx:02d}[/] "
             f"┊ [#ff9900 italic]source={H.grib_source}[/]"
         )
-    except:
+    except (ImportError, ModuleNotFoundError):
         print("rich is not working/installed")
 
 
@@ -119,8 +160,7 @@ def print_rich(H):
 
 def HerbieLogo(white_line=False):
     """Logo of Herbie The Love Bug"""
-    import matplotlib.patheffects as path_effects
-    import matplotlib.pyplot as plt
+    try_import("matplotlib.pyplot", as_name="plt")
 
     plt.figure(figsize=[5, 5], facecolor=hc.tan)
 
@@ -171,8 +211,8 @@ def HerbieLogo2(white_line=False, text_color="tan", text_stroke="black"):
     >>> ax = HerbieLogo2(text_color='tan')
     >>> plt.savefig('Herbie_transparent_tan.svg', bbox_inches="tight", transparent=True)
     """
-    import matplotlib.patheffects as path_effects
-    import matplotlib.pyplot as plt
+    try_import("matplotlib.pyplot", as_name="plt")
+    try_import("matplotlib.patheffects", as_name="path_effects")
 
     plt.figure(figsize=[5, 3], facecolor=hc.tan)
 

--- a/herbie/misc.py
+++ b/herbie/misc.py
@@ -18,17 +18,6 @@
   ██  ██  ██  ██  ██  ██  ██  ██  ██  ██  ██  ██  ██  ██  ██  ██  ██  ██
 """
 
-import warnings
-
-try:
-    import matplotlib.pyplot as plt
-    import matplotlib.patheffects as path_effects
-except ModuleNotFoundError:
-    warnings.warn(
-        "matplotlib is an 'extra' requirement, please use "
-        "`pip install 'herbie-data[extras]'` for the full functionality."
-)
-
 
 class hc:
     """Herbie Color Pallette"""
@@ -130,6 +119,13 @@ def print_rich(H):
 
 def HerbieLogo(white_line=False):
     """Logo of Herbie The Love Bug"""
+    try:
+        import matplotlib.pyplot as plt
+    except ModuleNotFoundError:
+        raise ModuleNotFoundError(
+            "matplotlib is an 'extra' requirement, please use "
+            "`pip install 'herbie-data[extras]'` for the full functionality."
+    )
     plt.figure(figsize=[5, 5], facecolor=hc.tan)
 
     plt.axis([-10, 10, -10, 10])
@@ -179,6 +175,14 @@ def HerbieLogo2(white_line=False, text_color="tan", text_stroke="black"):
     >>> ax = HerbieLogo2(text_color='tan')
     >>> plt.savefig('Herbie_transparent_tan.svg', bbox_inches="tight", transparent=True)
     """
+    try:
+        import matplotlib.pyplot as plt
+        import matplotlib.patheffects as path_effects
+    except ModuleNotFoundError:
+        raise ModuleNotFoundError(
+            "matplotlib is an 'extra' requirement, please use "
+            "`pip install 'herbie-data[extras]'` for the full functionality."
+    )
     plt.figure(figsize=[5, 3], facecolor=hc.tan)
 
     plt.axis([1.5, 20, -10, 10])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,14 +30,11 @@ keywords = [
     "HRRR",
 ]
 dependencies = [
-    "cartopy",
     "cfgrib",
-    "matplotlib",
-    "metpy",
     "numpy",
     "pandas",
     "pygrib",
-    "scikit-learn",
+    "requests",
     "toml",
     "xarray",
 ]
@@ -51,6 +48,7 @@ dynamic = ["version"]
 "Bug Tracker" = "https://github.com/blaylockbk/Herbie/issues"
 
 [project.optional-dependencies]
+extras = ["cartopy", "metpy", "scikit-learn"]
 docs = [
     "autodocsumm",
     "ipython",

--- a/tests/test_accessors.py
+++ b/tests/test_accessors.py
@@ -4,8 +4,6 @@ Note: See `test_pick_points.py` for testing the pick_points accessor.
 """
 
 from herbie import Herbie
-from shapely.geometry import MultiPoint
-import pandas as pd
 
 
 def test_crs():


### PR DESCRIPTION
@blaylockbk this is an attempt to make those libraries used by the accessors extra dependencies. I created a [little function](https://github.com/rafa-guedes/Herbie/blob/optional_dependencies/herbie/misc.py#L85) to conditionally import modules or functions and throw a message indicating `[extras]` need to be installed if the import fails, to avoid repeating this over and over. The downside of this approach is that linting fails to recognise libraries imported that way so happy to change this is you don't think it is a good idea.

A few points to notice:

- `metpy`, `scikit-learn`, `cartopy` turned into `[extras]` optional dependencies
- `matplotlib` removed altogether since it is a dependency in metpy
- `requests` explicitly added to the required dependencies list, this is required in core and it wasn't being installed after these changes.
- The optional dependencies are attempted to be imported inside the accessor class to avoid extra warnings
- Small note added to the installation section in the docs. I also removed the note mentioning `cfgrib` needing to be manually installed since it is prescribed in pyproject.toml as a required dependency.