### PR TITLE
Update new URL for ECMWF's AIFS model

### DIFF
--- a/herbie/models/ecmwf.py
+++ b/herbie/models/ecmwf.py
@@ -93,20 +93,28 @@ class aifs:
 
         product_suffix = "fc"
 
-        if self.date <= datetime(2025, 2, 9, 12):
+        if self.date >= datetime(2025, 2, 24, 6):
+            # ECMWF’s AI forecasts become operational
+            # https://www.ecmwf.int/en/about/media-centre/news/2025/ecmwfs-ai-forecasts-become-operational
             post_root = (
-                f"{self.date:%Y%m%d/%Hz}/aifs/0p25/{self.product}"
+                f"{self.date:%Y%m%d/%Hz}/aifs-single/0p25/{self.product}"
+                f"/{self.date:%Y%m%d%H%M%S}-{self.fxx}h-{self.product}-{product_suffix}.grib2"
+            )
+        elif self.date >= datetime(2025, 2, 9, 12):
+            # Preparing for the operational phase of the AI forecast
+            post_root = (
+                f"{self.date:%Y%m%d/%Hz}/aifs-single/0p25/experimental/{self.product}"
                 f"/{self.date:%Y%m%d%H%M%S}-{self.fxx}h-{self.product}-{product_suffix}.grib2"
             )
         else:
             post_root = (
-                f"{self.date:%Y%m%d/%Hz}/aifs-single/0p25/{self.product}"
+                f"{self.date:%Y%m%d/%Hz}/aifs/0p25/{self.product}"
                 f"/{self.date:%Y%m%d%H%M%S}-{self.fxx}h-{self.product}-{product_suffix}.grib2"
             )
 
         self.SOURCES = {
             "aws": f"https://ecmwf-forecasts.s3.eu-central-1.amazonaws.com/{post_root}",
-            "ecmwf":  f"https://data.ecmwf.int/forecasts/{post_root}",
+            "ecmwf": f"https://data.ecmwf.int/forecasts/{post_root}",
             "azure": f"https://ai4edataeuwest.blob.core.windows.net/ecmwf/{post_root}",
         }
         self.IDX_SUFFIX = [".index"]

--- a/herbie/models/ecmwf.py
+++ b/herbie/models/ecmwf.py
@@ -93,7 +93,7 @@ class aifs:
 
         product_suffix = "fc"
 
-        if self.date >= datetime(2025, 2, 24, 6):
+        if self.date >= datetime(2025, 2, 25, 6):
             # ECMWF’s AI forecasts become operational
             # https://www.ecmwf.int/en/about/media-centre/news/2025/ecmwfs-ai-forecasts-become-operational
             post_root = (

--- a/herbie/models/ecmwf.py
+++ b/herbie/models/ecmwf.py
@@ -85,6 +85,7 @@ class aifs:
         }
         self.PRODUCTS = {
             "oper": "operational high-resolution forecast, atmospheric fields",
+            "experimental": "experimental high-resolution forecast, atmospheric fields",
         }
 
         # example file
@@ -92,15 +93,21 @@ class aifs:
 
         product_suffix = "fc"
 
-        post_root = (
-            f"{self.date:%Y%m%d/%Hz}/aifs/0p25/{self.product}"
-            f"/{self.date:%Y%m%d%H%M%S}-{self.fxx}h-{self.product}-{product_suffix}.grib2"
-        )
+        if self.date <= datetime(2025, 2, 9, 12):
+            post_root = (
+                f"{self.date:%Y%m%d/%Hz}/aifs/0p25/{self.product}"
+                f"/{self.date:%Y%m%d%H%M%S}-{self.fxx}h-{self.product}-{product_suffix}.grib2"
+            )
+        else:
+            post_root = (
+                f"{self.date:%Y%m%d/%Hz}/aifs-single/0p25/{self.product}"
+                f"/{self.date:%Y%m%d%H%M%S}-{self.fxx}h-{self.product}-{product_suffix}.grib2"
+            )
 
         self.SOURCES = {
-            "azure": f"https://ai4edataeuwest.blob.core.windows.net/ecmwf/{post_root}",
             "aws": f"https://ecmwf-forecasts.s3.eu-central-1.amazonaws.com/{post_root}",
-            "ecmwf": f"https://data.ecmwf.int/forecasts/{post_root}",
+            "ecmwf":  f"https://data.ecmwf.int/forecasts/{post_root}",
+            "azure": f"https://ai4edataeuwest.blob.core.windows.net/ecmwf/{post_root}",
         }
         self.IDX_SUFFIX = [".index"]
         self.IDX_STYLE = "eccodes"  # 'wgrib2' or 'eccodes'

--- a/tests/test_ecmwf.py
+++ b/tests/test_ecmwf.py
@@ -49,6 +49,41 @@ def test_ifs_xarray(date, filter):
     H.get_localFilePath(filter).unlink()
 
 
-def test_aifs_yesterday():
-    H = Herbie(yesterday, model="aifs", save_dir=save_dir, overwrite=True)
-    H.xarray(":10(?:u|v):")
+class TestAIFS:
+    """Tests for ECMWF's AIFS model."""
+
+    def test_aifs_yesterday(self):
+        """Test downloading AIFS data from yesterday."""
+        H = Herbie(
+            yesterday,
+            model="aifs",
+            save_dir=save_dir,
+            overwrite=True,
+        )
+
+        assert H.grib, "AIFS GRIB file not found"
+        assert H.idx, "AIFS index file not found"
+
+        ds = H.xarray(":10(?:u|v):")
+        assert len(ds)
+
+    @pytest.mark.parametrize(
+        "date",
+        (
+            datetime(2025, 1, 1),
+            datetime(2025, 2, 9, 6),
+            datetime(2025, 2, 9, 12),
+            datetime(2025, 2, 24, 0),
+            datetime(2025, 2, 24, 6),
+        ),
+    )
+    def test_aifs_path_changes(self, date):
+        """Test files are valid on dates the paths changed."""
+        H = Herbie(
+            date,
+            model="aifs",
+            save_dir=save_dir,
+            overwrite=True,
+        )
+        assert H.grib
+        assert H.idx

--- a/tests/test_ecmwf.py
+++ b/tests/test_ecmwf.py
@@ -73,8 +73,8 @@ class TestAIFS:
             datetime(2025, 1, 1),
             datetime(2025, 2, 9, 6),
             datetime(2025, 2, 9, 12),
-            datetime(2025, 2, 24, 0),
-            datetime(2025, 2, 24, 6),
+            datetime(2025, 2, 25, 0),
+            datetime(2025, 2, 25, 6),
         ),
     )
     def test_aifs_path_changes(self, date):


### PR DESCRIPTION
It looks like the URL changed for the AIFS starting `2025-02-10 12z`

> Source: https://www.ecmwf.int/en/about/media-centre/news/2025/ecmwfs-ai-forecasts-become-operational

- [x] Update tests to confirm this works
- [ ] Check all the remotes (maybe need to finish #395)

```python
from herbie import Herbie

H = Herbie("2025-01-01", model="aifs")
H.grib, H.idx


---
('https://ecmwf-forecasts.s3.eu-central-1.amazonaws.com/20250101/00z/aifs/0p25/oper/20250101000000-0h-oper-fc.grib2',
 'https://ecmwf-forecasts.s3.eu-central-1.amazonaws.com/20250101/00z/aifs/0p25/oper/20250101000000-0h-oper-fc.index')
```

```python
H = Herbie("2025-03-02", model="aifs")
H.grib, H.idx

---
('https://ecmwf-forecasts.s3.eu-central-1.amazonaws.com/20250302/00z/aifs-single/0p25/oper/20250302000000-0h-oper-fc.grib2',
 'https://ecmwf-forecasts.s3.eu-central-1.amazonaws.com/20250302/00z/aifs-single/0p25/oper/20250302000000-0h-oper-fc.index')
```

---
Closes #414 