### PR TITLE
Handle case where search string results in no subsets

### DIFF
--- a/src/herbie/core.py
+++ b/src/herbie/core.py
@@ -914,7 +914,7 @@ class Herbie:
                     f"Found {ANSI.bold}{ANSI.green}{len(idx_df)}{ANSI.reset} grib messages."
                 )
             if len(idx_df) == 0:
-                msg = f"🦨 No subsets found with search string {search} in {self.model=} {self.date=} {self.fxx=}"
+                msg = f"🦨 No subsets found with {search=} in {self.model=} {self.date=} {self.fxx=}"
                 if errors == "warn":
                     log.warning(msg)
                     return # Nothing to download

--- a/src/herbie/core.py
+++ b/src/herbie/core.py
@@ -913,6 +913,14 @@ class Herbie:
                 print(
                     f"Found {ANSI.bold}{ANSI.green}{len(idx_df)}{ANSI.reset} grib messages."
                 )
+            if len(idx_df) == 0:
+                msg = f"🦨 No subsets found with search string {search} in {self.model=} {self.date=} {self.fxx=}"
+                if errors == "warn":
+                    log.warning(msg)
+                    return # Nothing to download
+                elif errors == "raise":
+                    raise ValueError(msg)
+
             idx_df["download_groups"] = idx_df.grib_message.diff().ne(1).cumsum()
 
             # cURL subsets of each group


### PR DESCRIPTION
Hi Brian,

I ran into an problem where some of the remote grib files on AWS are missing the variables I'm targeting. This PR handles this error case in a better way. If you want to test it:

```python
Herbie("2009-10-19 03:00:00", model="gefs_wave_reforecast", member=0, save_dir="./GEFS").xarray(rf":(?:HTSGW|DIRPW|PERPW):surface:(?:anl|(?:3|6|9|12|15|18|21) hour fcst)", remove_grib=True, backend_kwargs=dict(decode_timedelta=False), overwrite=True, verbose=True)
```
outputs

```
✅ Found ┊ model=gefs_wave_reforecast ┊ product=GEFSv12/wave_reforecast ┊ 2009-Oct-19 03:00 UTC F00 ┊ GRIB2 @ aws ┊ IDX @ aws
🦨 No subsets found with search string :(?:HTSGW|DIRPW|PERPW):surface:(?:anl|(?:3|6|9|12|15|18|21) hour fcst) in self.model='gefs_wave_reforecast' self.date=Timestamp('2009-10-19 03:00:00') self.fxx=0
📇 Download subset: ▌▌Herbie GEFS_WAVE_REFORECAST model GEFSv12/wave_reforecast product initialized 2009-Oct-19 03:00 UTC F00 ┊ source=aws                                                            
 cURL from https://noaa-nws-gefswaves-reforecast-pds.s3.amazonaws.com/GEFSv12/reforecast/2009/20091019/gridded/gefs.wave.20091019.c00.global.0p25.grib2
Found 0 grib messages.
```

Cheers,
Nick