### PR TITLE
fix product validation

### DIFF
--- a/src/herbie/core.py
+++ b/src/herbie/core.py
@@ -223,6 +223,9 @@ class Herbie:
         # (see https://stackoverflow.com/a/7936588/2383070 for what I'm doing here)
         getattr(model_templates, self.model).template(self)
 
+        # Check the user input
+        self._validate()
+
         if product is None:
             # The user didn't specify a product, so let's use the first
             # product in the model template.
@@ -245,9 +248,6 @@ class Herbie:
         self.IDX_STYLE = getattr(self, "IDX_STYLE", "wgrib2")
 
         self.search_help = _search_help(self.IDX_STYLE)
-
-        # Check the user input
-        self._validate()
 
         # Ok, now we are ready to look for the GRIB2 file at each of the remote sources.
         # self.grib is the first existing GRIB2 file discovered.


### PR DESCRIPTION
currently, inputting an invalid product leads to a generic `keyerror`

<img width="181" height="56" alt="Screenshot 2025-08-02 at 2 51 39 PM" src="https://github.com/user-attachments/assets/6794f151-c572-4b09-9a12-dfad119a6fad" />

by calling `_validate()` earlier, we can throw a more useful assertion error:

<img width="857" height="41" alt="Screenshot 2025-08-02 at 2 51 16 PM" src="https://github.com/user-attachments/assets/bfd29ef9-eb22-4688-9680-a381d5a99a2e" />
