### PR TITLE
erroneous overwrite param in find_grib()

### DIFF
--- a/src/herbie/core.py
+++ b/src/herbie/core.py
@@ -1004,7 +1004,7 @@ class Herbie:
 
         if self.overwrite and self.grib_source.startswith("local"):
             # Search for the grib files on the remote archives again
-            self.grib, self.grib_source = self.find_grib(overwrite=True)
+            self.grib, self.grib_source = self.find_grib()
             self.idx, self.idx_source = self.find_idx()
             print(f"Overwrite local file with file from [{self.grib_source}]")
 


### PR DESCRIPTION
calling download(overwrite=True) lead to the following broken code branch
<img width="925" height="472" alt="Screenshot 2025-08-02 at 3 12 36 PM" src="https://github.com/user-attachments/assets/d74a91e4-1d4b-4f48-bf43-1cf5a4d46ac4" />

