### PR TITLE
add google as source for ecmwf

### DIFF
--- a/src/herbie/models/ecmwf.py
+++ b/src/herbie/models/ecmwf.py
@@ -69,6 +69,7 @@ class ifs:
             "azure-waef": f"https://ai4edataeuwest.blob.core.windows.net/ecmwf/{post_root.replace('wave', 'waef')}",
             "aws": f"https://ecmwf-forecasts.s3.eu-central-1.amazonaws.com/{post_root}",
             "ecmwf": f"https://data.ecmwf.int/forecasts/{post_root}",
+            "google": f"https://storage.googleapis.com/ecmwf-open-data/{post_root}",
         }
         self.IDX_SUFFIX = [".index"]
         self.IDX_STYLE = "eccodes"  # 'wgrib2' or 'eccodes'
@@ -138,6 +139,7 @@ class aifs:
             "aws": f"https://ecmwf-forecasts.s3.eu-central-1.amazonaws.com/{post_root}",
             "ecmwf": f"https://data.ecmwf.int/forecasts/{post_root}",
             "azure": f"https://ai4edataeuwest.blob.core.windows.net/ecmwf/{post_root}",
+            "google": f"https://storage.googleapis.com/ecmwf-open-data/{post_root}",
         }
         self.IDX_SUFFIX = [".index"]
         self.IDX_STYLE = "eccodes"  # 'wgrib2' or 'eccodes'


### PR DESCRIPTION
Closes #488. I ran a quick test for IFS and AIFS:

```python
from herbie import Herbie
H = Herbie("2025-08-01", model="aifs", fxx=12, priority='google')
ds = H.xarray(":10[u|v]:", verbose=True).herbie.with_wind()
ds
```
returns
```
✅ Found ┊ model=aifs ┊ product=oper ┊ 2025-Aug-01 00:00 UTC F12 ┊ GRIB2 @ google ┊ IDX @ google
📇 Download subset: ▌▌Herbie AIFS model oper product initialized 2025-Aug-01 00:00 UTC F12 ┊ source=google                                                            
 cURL from https://storage.googleapis.com/ecmwf-open-data/20250801/00z/aifs-single/0p25/oper/20250801000000-12h-oper-fc.grib2
Found 2 grib messages.
Download subset group 1
  31  :10u:sfc:g:0001:ai:fc:oper
curl -s --range 22407231-23140361 "https://storage.googleapis.com/ecmwf-open-data/20250801/00z/aifs-single/0p25/oper/20250801000000-12h-oper-fc.grib2" > "C:\Users\willh\data\aifs\20250801\subset_2a12f4e9__20250801000000-12h-oper-fc.grib2"
Download subset group 2
  36  :10v:sfc:g:0001:ai:fc:oper
curl -s --range 25663531-26423334 "https://storage.googleapis.com/ecmwf-open-data/20250801/00z/aifs-single/0p25/oper/20250801000000-12h-oper-fc.grib2" >> "C:\Users\willh\data\aifs\20250801\subset_2a12f4e9__20250801000000-12h-oper-fc.grib2"
💾 Saved the subset to [C:\Users\willh\data\aifs\20250801\subset_2a12f4e9__20250801000000-12h-oper-fc.grib2](file:///C:/Users/willh/data/aifs/20250801/subset_2a12f4e9__20250801000000-12h-oper-fc.grib2)
[c:\Users\willh\Documents\Python](file:///C:/Users/willh/Documents/Python) Scripts\forecast_test_temp\.venv\Lib\site-packages\cfgrib\xarray_store.py:51: FutureWarning: In a future version of xarray the default value for compat will change from compat='no_conflicts' to compat='override'. This is likely to lead to different results when combining overlapping variables with the same name. To opt in to new defaults and get rid of these warnings now use `set_options(use_new_combine_kwarg_defaults=True) or set compat explicitly.
  o = xr.merge([o, ds], **kwargs)
``` 
and a preview of the dataset, and

```python
H = Herbie("2025-08-01", model="ifs", fxx=12, priority='google', verbose=True)
ds = H.xarray(":10[u|v]:", verbose=True).herbie.with_wind()
```
returns

```
✅ Found ┊ model=ifs ┊ product=oper ┊ 2025-Aug-01 00:00 UTC F12 ┊ GRIB2 @ google ┊ IDX @ google
📇 Download subset: ▌▌Herbie IFS model oper product initialized 2025-Aug-01 00:00 UTC F12 ┊ source=google                                                            
 cURL from https://storage.googleapis.com/ecmwf-open-data/20250801/00z/ifs/0p25/oper/20250801000000-12h-oper-fc.grib2
Found 2 grib messages.
Download subset group 1
  67  :10u:sfc:g:0001:od:fc:oper
curl -s --range 51900006-52773034 "https://storage.googleapis.com/ecmwf-open-data/20250801/00z/ifs/0p25/oper/20250801000000-12h-oper-fc.grib2" > "C:\Users\willh\data\ifs\20250801\subset_2a12ae51__20250801000000-12h-oper-fc.grib2"
Download subset group 2
  74  :10v:sfc:g:0001:od:fc:oper
curl -s --range 57684018-58554505 "https://storage.googleapis.com/ecmwf-open-data/20250801/00z/ifs/0p25/oper/20250801000000-12h-oper-fc.grib2" >> "C:\Users\willh\data\ifs\20250801\subset_2a12ae51__20250801000000-12h-oper-fc.grib2"
💾 Saved the subset to [C:\Users\willh\data\ifs\20250801\subset_2a12ae51__20250801000000-12h-oper-fc.grib2](file:///C:/Users/willh/data/ifs/20250801/subset_2a12ae51__20250801000000-12h-oper-fc.grib2)
[c:\Users\willh\Documents\Python](file:///C:/Users/willh/Documents/Python) Scripts\forecast_test_temp\.venv\Lib\site-packages\cfgrib\xarray_store.py:51: FutureWarning: In a future version of xarray the default value for compat will change from compat='no_conflicts' to compat='override'. This is likely to lead to different results when combining overlapping variables with the same name. To opt in to new defaults and get rid of these warnings now use `set_options(use_new_combine_kwarg_defaults=True) or set compat explicitly.
  o = xr.merge([o, ds], **kwargs)
```
