### PR TITLE
Register RRFS 2dfld product after NOAA file split

### DIFF
--- a/docs/gallery/noaa_models/rrfs.ipynb
+++ b/docs/gallery/noaa_models/rrfs.ipynb
@@ -633,6 +633,8 @@
    "source": [
     "### Other products\n",
     "\n",
+    "RRFS also publishes `natlev` (native model levels), `2dfld` (2D surface/post-processed fields), `testbed`, and `ififip` products.\n",
+    "\n",
     "> Reading natlev data into xarray causes my kernel to crash\n"
    ]
   },

--- a/src/herbie/models/rrfs.py
+++ b/src/herbie/models/rrfs.py
@@ -6,7 +6,7 @@ HELP = r"""
 Herbie(date, model='rrfs', ...)
 
 fxx : int
-product : {"prs", "nat", "testbed", "ififip"}
+product : {"prs", "nat", "2dfld", "testbed", "ififip"}
 member : {None, int}
     None for deterministic run, int (1-5) for ensemble members
 domain : {"conus", "alaska", "hawaii", "puerto rico", "na"}
@@ -26,6 +26,7 @@ class rrfs:
         self.PRODUCTS = {
             "prslev": "pressure level fields",
             "natlev": "native level fields",
+            "2dfld": "2D surface/post-processed fields",
             "testbed": "testbed fields",
             "ififip": "icing/freezing fields",
         }

--- a/tests/test_rrfs.py
+++ b/tests/test_rrfs.py
@@ -97,3 +97,17 @@ def test_rrfs_natlev_file_exists():
     )
     assert H.grib, "RRFS natlev grib2 file not found"
     assert H.idx, "RRFS natlev index file not found"
+
+
+def test_rrfs_2dfld_product_accepted():
+    """2dfld should be a valid product and default to domain='conus'."""
+    H = Herbie(
+        today,
+        model="rrfs",
+        product="2dfld",
+        fxx=0,
+        save_dir=save_dir,
+    )
+    assert H.product == "2dfld"
+    assert H.domain == "conus"
+    assert "2dfld" in H.SOURCES["aws"]


### PR DESCRIPTION
## Context

Around 2026-04-16, NOAA began publishing a new `2dfld` (2D surface / post-processed fields) product to the RRFS S3 bucket alongside `prslev`. Both files now appear for every hourly cycle:

```
rrfs_a/rrfs.20260417/12/rrfs.t12z.2dfld.3km.f001.conus.grib2   (HEAD 200)
rrfs_a/rrfs.20260417/12/rrfs.t12z.prslev.3km.f001.conus.grib2  (HEAD 200)
```

Same URL shape, same resolution, all non-NA domains (CONUS/AK/HI/PR). Not yet reflected on [the AWS registry page](https://registry.opendata.aws/noaa-rrfs/), but live in the bucket.

## Problem

`Herbie(date, model="rrfs", product="2dfld", fxx=0)` fails at `core.py:_validate()`:

    AssertionError: `product` must be one of {'natlev', 'testbed', 'ififip', 'prslev'}

because `rrfs.template()` doesn't register the key.

## Fix

- Register `"2dfld"` in `rrfs.PRODUCTS` (`src/herbie/models/rrfs.py`)
- Mention it in the `HELP` docstring and the RRFS gallery notebook
- Add a template-validation test (`tests/test_rrfs.py`)

No URL logic changes — `self.product` is already interpolated into the existing filename pattern.

## Verification

- End-to-end: `Herbie(datetime(2026, 4, 17, 12), model="rrfs", product="2dfld", fxx=1)` now resolves GRIB2 + IDX on AWS
- `pytest tests/test_rrfs.py` — 11/11 pass
