### PR TITLE
Fix GEFS chem.5 URL and FastHerbie warning denominator

### DIFF
--- a/src/herbie/fast.py
+++ b/src/herbie/fast.py
@@ -170,7 +170,7 @@ class FastHerbie:
 
         if len(self.file_not_exists) > 0:
             log.warning(
-                f"Could not find {len(self.file_not_exists)}/{len(self.file_exists)} GRIB files."
+                f"Could not find {len(self.file_not_exists)}/{len(self.file_not_exists) + len(self.file_exists)} GRIB files."
             )
 
     def __len__(self) -> int:

--- a/src/herbie/models/gefs.py
+++ b/src/herbie/models/gefs.py
@@ -73,7 +73,7 @@ class gefs:
                 "atmos.5b": f"{filedir}/atmos/pgrb2bp5/ge{self.member}.t{self.date:%H}z.pgrb2b.0p50.f{self.fxx:03d}",
                 "atmos.25": f"{filedir}/atmos/pgrb2sp25/ge{self.member}.t{self.date:%H}z.pgrb2s.0p25.f{self.fxx:03d}",
                 "wave": f"{filedir}/wave/gridded/gefs.wave.t{self.date:%H}z.{self.member}.global.0p25.f{self.fxx:03d}.grib2",
-                "chem.5": f"{filedir}/chem/pgrb2ap25/gefs.chem.t{self.date:%H}z.a2d_0p25.f{self.fxx:03d}.grib2",
+                "chem.5": f"{filedir}/chem/pgrb2ap5/gefs.chem.t{self.date:%H}z.a3d_0p50.f{self.fxx:03d}.grib2",
                 "chem.25": f"{filedir}/chem/pgrb2ap25/gefs.chem.t{self.date:%H}z.a2d_0p25.f{self.fxx:03d}.grib2",
             }
 

--- a/tests/test_gefs.py
+++ b/tests/test_gefs.py
@@ -35,3 +35,17 @@ def test_gefs_reforecast():
 
     assert H.grib, "GEFS grib2 file not found"
     assert H.idx, "GEFS index file not found"
+
+
+def test_gefs_chem5_uses_half_degree_path():
+    """chem.5 must resolve to the 0.5° bucket path, not the 0.25° one."""
+    H = Herbie(
+        "2023-06-08 00:00",
+        model="gefs",
+        product="chem.5",
+        member="c00",
+        fxx=3,
+        save_dir=save_dir,
+    )
+    assert "pgrb2ap5" in H.SOURCES["aws"]
+    assert "a3d_0p50" in H.SOURCES["aws"]


### PR DESCRIPTION
## Summary
- Fix GEFS `chem.5` resolving to the 0.25° bucket path — now points to `chem/pgrb2ap5/... a3d_0p50.f{fxx}.grib2`
- Fix `FastHerbie` "Could not find X/Y GRIB files" warning: denominator was `len(file_exists)` instead of total
- Add regression test for GEFS `chem.5` URL construction

Fixes #516
Fixes #523

## Test plan
- [x] `pytest tests/test_gefs.py` — passes (incl. new `test_gefs_chem5_uses_half_degree_path`)
- [x] Verified `chem.5` URL resolves to a real file on S3 (HEAD 200)
- [x] Confirmed `chem.25` path is unchanged
