### PR TITLE
GEFS Wave product: include control ensemble

### DIFF
--- a/src/herbie/models/gefs.py
+++ b/src/herbie/models/gefs.py
@@ -81,7 +81,8 @@ class gefs:
             "atmos.5": [f"p{i:02d}" for i in range(1, 31)] + ["c00", "spr", "avg"],
             "atmos.5b": [f"p{i:02d}" for i in range(1, 31)] + ["c00"],
             "atmos.25": [f"p{i:02d}" for i in range(1, 31)] + ["c00", "spr", "avg"],
-            "wave": [f"p{i:02d}" for i in range(1, 31)] + ["spread", "mean", "prob"],
+            "wave": [f"p{i:02d}" for i in range(1, 31)]
+            + ["c00", "spread", "mean", "prob"],
             "chem.5": None,
             "chem.25": None,
         }


### PR DESCRIPTION
adds c00 - the control ensemble member- in to the gefs.wave product. The wave product should have all 31 members, including the control group. [See inventory here](https://www.nco.ncep.noaa.gov/pmb/products/gens/).

This seems to work fine on my end.